### PR TITLE
Allow support for data-* tags, delivers on the previous issue #159

### DIFF
--- a/src/main/java/org/owasp/validator/html/InternalPolicy.java
+++ b/src/main/java/org/owasp/validator/html/InternalPolicy.java
@@ -28,6 +28,7 @@ public class InternalPolicy extends Policy {
     private final boolean preserveComments;
     private final boolean embedStyleSheets;
     private final boolean isEncodeUnknownTag;
+    private final boolean allowDynamicAttributes;
 
 
     protected InternalPolicy(URL baseUrl, ParseContext parseContext) throws PolicyException {
@@ -47,6 +48,7 @@ public class InternalPolicy extends Policy {
         this.preserveComments = isTrue(Policy.PRESERVE_COMMENTS);
         this.styleTag = getTagByLowercaseName("style");
         this.embedStyleSheets = isTrue(Policy.EMBED_STYLESHEETS);
+        this.allowDynamicAttributes = isTrue(Policy.ALLOW_DYNAMIC_ATTRIBUTES);
     }
 
     protected InternalPolicy(Policy old, Map<String, String> directives, Map<String, Tag> tagRules) {
@@ -66,6 +68,7 @@ public class InternalPolicy extends Policy {
         this.preserveComments = isTrue(Policy.PRESERVE_COMMENTS);
         this.styleTag = getTagByLowercaseName("style");
         this.embedStyleSheets = isTrue(Policy.EMBED_STYLESHEETS);
+        this.allowDynamicAttributes = isTrue(Policy.ALLOW_DYNAMIC_ATTRIBUTES);
     }
 
     public Tag getEmbedTag() {
@@ -131,6 +134,10 @@ public class InternalPolicy extends Policy {
 
     public boolean isEncodeUnknownTag() {
         return isEncodeUnknownTag;
+    }
+
+    public boolean isAllowDynamicAttributes() {
+        return allowDynamicAttributes;
     }
 
     /**

--- a/src/main/java/org/owasp/validator/html/scan/MagicSAXFilter.java
+++ b/src/main/java/org/owasp/validator/html/scan/MagicSAXFilter.java
@@ -283,6 +283,10 @@ public class MagicSAXFilter extends DefaultFilter implements XMLDocumentFilter {
 					if (attribute == null) {
 						// no policy defined, perhaps it is a global attribute
 						attribute = policy.getGlobalAttributeByName(nameLower);
+						if (attribute == null && policy.isAllowDynamicAttributes()) {
+						    // not a global attribute, perhaps it is a dynamic attribute, if allowed
+						    attribute = policy.getDynamicAttributeByName(nameLower);
+						}
 					}
 					// boolean isAttributeValid = false;
 					if ("style".equalsIgnoreCase(name)) {

--- a/src/main/resources/antisamy.xml
+++ b/src/main/resources/antisamy.xml
@@ -27,6 +27,8 @@ http://www.w3.org/TR/html401/struct/global.html
 		<directive name="connectionTimeout" value="5000"/>
 		<directive name="maxStyleSheetImports" value="3"/>
 		
+		<!-- Allows the use of dynamic attributes (i.e. HTML5 "data-") -->
+		<directive name="allowDynamicAttributes" value="true" />
 	</directives>
 	
 	<common-regexps>
@@ -183,7 +185,12 @@ http://www.w3.org/TR/html401/struct/global.html
 		 	</regexp-list>
 		 </attribute>
 
-		 
+		<attribute name="data-" description="Allows the HTML5 'data-' attribute to be added to elements">
+			<regexp-list>
+				<regexp name="anything"/>
+			</regexp-list>
+		</attribute>
+
  		<!-- the "style" attribute will be validated by an inline stylesheet scanner, so no need to define anything here - i hate having to special case this but no other choice -->
 		 <attribute name="style" description="The 'style' attribute provides the ability for users to change many attributes of the tag's contents using a strict syntax"/>
 		 
@@ -500,7 +507,12 @@ http://www.w3.org/TR/html401/struct/global.html
 		<!-- Not valid in base, br, frame, frameset, hr, iframe, param, and script elements.  -->
 		<attribute name="lang"/>
 	</global-tag-attributes>
-	
+
+	<!-- Declare "dynamic" tag attributes here. The directive "allowDynamicAttributes" must be set to true -->
+	<dynamic-tag-attributes>
+		<attribute name="data-"/> <!-- HTML5 "data-" tag -->
+	</dynamic-tag-attributes>
+
 	<tags-to-encode>
 		<tag>g</tag>
 		<tag>grin</tag>

--- a/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
@@ -1209,6 +1209,23 @@ public class AntiSamyTest {
     }
 
     @Test
+    public void testDataTag159() throws ScanException, PolicyException {
+        /* issue #159 - allow dynamic HTML5 data-* attribute */
+        String good = "<p data-tag=\"abc123\">Hello World!</p>";
+        String bad = "<p dat-tag=\"abc123\">Hello World!</p>";
+        String goodExpected = "<p data-tag=\"abc123\">Hello World!</p>";
+        String badExpected = "<p>Hello World!</p>";
+        // test good attribute "data-"
+        CleanResults cr = as.scan(good, policy, AntiSamy.SAX);
+        String s = cr.getCleanHTML();
+        assertEquals(goodExpected, s);
+        // test bad attribute "dat-"
+        cr = as.scan(bad, policy, AntiSamy.SAX);
+        s = cr.getCleanHTML();
+        assertEquals(badExpected, s);
+    }
+
+    @Test
     public void testXSSInAntiSamy151() throws ScanException, PolicyException {
         String test = "<bogus>whatever</bogus><img src=\"https://ssl.gstatic.com/codesite/ph/images/defaultlogo.png\" "
             + "onmouseover=\"alert('xss')\">";

--- a/src/test/java/org/owasp/validator/html/test/PolicyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/PolicyTest.java
@@ -27,13 +27,14 @@ public class PolicyTest extends TestCase {
     private static final String DIRECTIVES = "<directives>\n</directives>\n";
     private static final String COMMON_ATTRIBUTES = "<common-attributes>\n</common-attributes>\n";
     private static final String GLOBAL_TAG_ATTRIBUTES = "<global-tag-attributes>\n</global-tag-attributes>\n";
+    private static final String DYNAMIC_TAG_ATTRIBUTES = "<dynamic-tag-attributes>\n</dynamic-tag-attributes>\n";
     private static final String TAG_RULES = "<tag-rules>\n</tag-rules>";
     private static final String CSS_RULES = "<css-rules>\n</css-rules>\n";
     private static final String COMMON_REGEXPS = "<common-regexps>\n</common-regexps>";
     private static final String FOOTER = "</anti-samy-rules>";
 
     private String assembleFile(String allowedEmptyTagsSection) {
-        return HEADER + DIRECTIVES + COMMON_REGEXPS + COMMON_ATTRIBUTES + GLOBAL_TAG_ATTRIBUTES + TAG_RULES + CSS_RULES +
+        return HEADER + DIRECTIVES + COMMON_REGEXPS + COMMON_ATTRIBUTES + GLOBAL_TAG_ATTRIBUTES + DYNAMIC_TAG_ATTRIBUTES + TAG_RULES + CSS_RULES +
                allowedEmptyTagsSection + FOOTER;
     }
 


### PR DESCRIPTION
https://code.google.com/archive/p/owaspantisamy/issues/159

Happy to see antisamy being released again. This was an old bug we'd fixed that would be nice to have incorporated into a release version. Allows support for dynamic attributes like data-* attributes. (For example)