### PR TITLE
Updating batik-css to 1.9 to address CVE-2017-5662

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-css</artifactId>
-            <version>1.8</version>
+            <version>1.9</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.nekohtml</groupId>


### PR DESCRIPTION
Compiled and ran all units test successfully.

Here's a link to the CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5662