### PR TITLE
Fix regular expressions in antisamy.xml

### DIFF
--- a/src/main/resources/antisamy.xml
+++ b/src/main/resources/antisamy.xml
@@ -9,7 +9,7 @@ http://www.w3.org/TR/html401/struct/global.html
 	
 <anti-samy-rules xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:noNamespaceSchemaLocation="antisamy.xsd">
-	
+	<!-- dummy commit to prove the github action works -->
 	<directives>
 		<directive name="omitXmlDeclaration" value="true"/>
 		<directive name="omitDoctypeDeclaration" value="true"/>

--- a/src/main/resources/antisamy.xml
+++ b/src/main/resources/antisamy.xml
@@ -49,7 +49,7 @@ http://www.w3.org/TR/html401/struct/global.html
 				
 		<regexp name="anything" value=".*"/>
 		<regexp name="numberOrPercent" value="(\d)+(%{0,1})"/>
-		<regexp name="paragraph" value="([\p{L}\p{N},'\.\s\-_\(\)\?]|&amp;[0-9]{2};)*"/>	
+		<regexp name="paragraph" value="([\p{L}\p{N},'\.\s\-_\(\)]|&amp;[0-9]{2};)*"/>
 		<regexp name="htmlId" value="[a-zA-Z0-9\:\-_\.]+"/>
 		<regexp name="htmlTitle" value="[\p{L}\p{N}\s\-_',:\[\]!\./\\\(\)&amp;]*"/> <!-- force non-empty with a '+' at the end instead of '*' -->
 		<regexp name="htmlClass" value="[a-zA-Z0-9\s,\-_]+"/>
@@ -229,7 +229,7 @@ http://www.w3.org/TR/html401/struct/global.html
 		<attribute name="name">
 		 	<regexp-list>
 		 		
-		 		<regexp value="[a-zA-Z0-9-\_\$]+"/>
+		 		<regexp value="[a-zA-Z0-9\-_\$]+"/>
 		 		
 		 		<!--
 		 		have to allow the $ for .NET controls - although,

--- a/src/main/resources/antisamy.xml
+++ b/src/main/resources/antisamy.xml
@@ -9,7 +9,7 @@ http://www.w3.org/TR/html401/struct/global.html
 	
 <anti-samy-rules xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:noNamespaceSchemaLocation="antisamy.xsd">
-	<!-- dummy commit to prove the github action works -->
+
 	<directives>
 		<directive name="omitXmlDeclaration" value="true"/>
 		<directive name="omitDoctypeDeclaration" value="true"/>


### PR DESCRIPTION
Fix the following regular expressions:
- `paragraph` (used for `alt` and `abbr` attributes): Questions marks need to be encoded in the used contexts, and must not appear otherwise. Remove the question mark as a permitted character.
- `name` attribute regular expression: The `-` character should be escaped, although in this instance it is not strictly necessary. The `_` character is escaped, although it doesn't need to be escaped. Clean up the regular expression by escaping `-` and not escaping `_`.
