### PR TITLE
In SAX parser: do not lose the closing tag when encoding an unknown element

### DIFF
--- a/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
@@ -467,13 +467,15 @@ public class AntiSamyTest {
     @Test
     public void isssue31() throws ScanException, PolicyException {
 
-        String test = "<b><u><g>foo";
+        String test = "<b><u><g>foo</g></u></b>";
         Policy revised = policy.cloneWithDirective("onUnknownTag", "encode");
         CleanResults cr = as.scan(test, revised, AntiSamy.DOM);
         String s = cr.getCleanHTML();
         assertFalse(!s.contains("&lt;g&gt;"));
+        assertFalse(!s.contains("&lt;/g&gt;"));
         s = as.scan(test, revised, AntiSamy.SAX).getCleanHTML();
         assertFalse(!s.contains("&lt;g&gt;"));
+        assertFalse(!s.contains("&lt;/g&gt;"));
 
         Tag tag = policy.getTagByLowercaseName("b").mutateAction("encode");
         Policy policy1 = policy.mutateTag(tag);
@@ -482,11 +484,13 @@ public class AntiSamyTest {
         s = cr.getCleanHTML();
 
         assertFalse(!s.contains("&lt;b&gt;"));
+        assertFalse(!s.contains("&lt;/b&gt;"));
 
         cr = as.scan(test, policy1, AntiSamy.SAX);
         s = cr.getCleanHTML();
 
         assertFalse(!s.contains("&lt;b&gt;"));
+        assertFalse(!s.contains("&lt;/b&gt;"));
     }
 
     @Test


### PR DESCRIPTION
When onUnknownTag directive specifies "encode", the SAX parser does not remember enough context to do the right thing when it sees a closing tag. So MagicSAXFilter encodes `<g></g>` into `&lt;g&gt;` instead of `&lt;g&gt&lt;/g&gt;` (Current master branch handles closing tag as if directive is "remove" instead of "encode" so closing tag gets lost.)
Also enhance the corresponding unit test to cover the closing tag case.
