### PR TITLE
Updated Batik CSS library version to resolve CVE-2018-8013

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.owasp.antisamy</groupId>
     <artifactId>antisamy</artifactId>
     <packaging>jar</packaging>
-    <version>1.5.7</version>
+    <version>1.5.8</version>
 
     <distributionManagement>
         <snapshotRepository>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-css</artifactId>
-            <version>1.9.1</version>
+            <version>1.10</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.nekohtml</groupId>


### PR DESCRIPTION
Updated Batik CSS library to resolve a newly discovered CVE. https://nvd.nist.gov/vuln/detail/CVE-2018-8013