### PR TITLE
Update batik-css from 1.12 to 1.13 to address CVE-2019-17566.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-css</artifactId>
-            <version>1.12</version>
+            <version>1.13</version>
             <exclusions>
                 <!-- exclude this as batik-css 1.12 has a dependency that uses commons-logging 1.0.4 and we want to eliminate the convergence mismatch -->
                 <exclusion>


### PR DESCRIPTION
See https://xmlgraphics.apache.org/security.html for details.
See also https://seclists.org/oss-sec/2020/q2/189#:~:text=CVE%2D2019%2D17566%3A%20Apache,underlying%20server%20to%20make%20arbitrary