### PR TITLE
 Remove multiple definition of tags on policy files

### DIFF
--- a/src/main/resources/antisamy-anythinggoes.xml
+++ b/src/main/resources/antisamy-anythinggoes.xml
@@ -738,8 +738,6 @@ http://www.w3.org/TR/html401/struct/global.html
 		<tag name="hr" action="validate"/>
 		<tag name="br" action="validate"/>
 
-		<tag name="col" action="validate"/>
-
 		<tag name="font" action="validate">
 			<attribute name="color">
 				<regexp-list>
@@ -2472,18 +2470,6 @@ http://www.w3.org/TR/html401/struct/global.html
 			<regexp-list>
 				<regexp name="cssIdentifier"/>
 				<regexp name="integer"/>
-			</regexp-list>
-		</property>
-		<property name="clip" default="auto" description="The 'clip' property applies to elements that have a 'overflow' property with a value other than 'visible'.">
-			<category-list>
-				<category value="visual"/>
-			</category-list>
-			<literal-list>
-				<literal value="auto"/>
-				<literal value="inherit"/>
-			</literal-list>
-			<regexp-list>
-				<regexp name="length"/>
 			</regexp-list>
 		</property>
 		<property name="cursor" default="auto" description="This property specifies the type of cursor to be displayed for the pointing device.">

--- a/src/main/resources/antisamy-ebay.xml
+++ b/src/main/resources/antisamy-ebay.xml
@@ -549,8 +549,6 @@ http://www.w3.org/TR/html401/struct/global.html
 		<tag name="hr" action="validate"/>
 		<tag name="br" action="validate"/>
 
-		<tag name="col" action="validate"/>
-
 		<tag name="font" action="validate">
 			<attribute name="color">
 				<regexp-list>
@@ -2280,18 +2278,6 @@ http://www.w3.org/TR/html401/struct/global.html
 			<regexp-list>
 				<regexp name="cssIdentifier"/>
 				<regexp name="integer"/>
-			</regexp-list>
-		</property>
-		<property name="clip" default="auto" description="The 'clip' property applies to elements that have a 'overflow' property with a value other than 'visible'.">
-			<category-list>
-				<category value="visual"/>
-			</category-list>
-			<literal-list>
-				<literal value="auto"/>
-				<literal value="inherit"/>
-			</literal-list>
-			<regexp-list>
-				<regexp name="length"/>
 			</regexp-list>
 		</property>
 		<property name="cursor" default="auto" description="This property specifies the type of cursor to be displayed for the pointing device.">

--- a/src/main/resources/antisamy-myspace.xml
+++ b/src/main/resources/antisamy-myspace.xml
@@ -711,8 +711,6 @@ http://www.w3.org/TR/html401/struct/global.html
 		<tag name="hr" action="validate"/>
 		<tag name="br" action="validate"/>
 
-		<tag name="col" action="validate"/>
-
 		<tag name="font" action="validate">
 			<attribute name="color">
 				<regexp-list>
@@ -2437,18 +2435,6 @@ http://www.w3.org/TR/html401/struct/global.html
 			<regexp-list>
 				<regexp name="cssIdentifier"/>
 				<regexp name="integer"/>
-			</regexp-list>
-		</property>
-		<property name="clip" default="auto" description="The 'clip' property applies to elements that have a 'overflow' property with a value other than 'visible'.">
-			<category-list>
-				<category value="visual"/>
-			</category-list>
-			<literal-list>
-				<literal value="auto"/>
-				<literal value="inherit"/>
-			</literal-list>
-			<regexp-list>
-				<regexp name="length"/>
 			</regexp-list>
 		</property>
 		<property name="cursor" default="auto" description="This property specifies the type of cursor to be displayed for the pointing device.">

--- a/src/main/resources/antisamy.xml
+++ b/src/main/resources/antisamy.xml
@@ -759,8 +759,6 @@ http://www.w3.org/TR/html401/struct/global.html
 		<tag name="hr" action="validate"/>
 		<tag name="br" action="validate"/>
 		
-		<tag name="col" action="validate"/>
-		
 		<tag name="font" action="validate">
 			<attribute name="color">
 				<regexp-list>
@@ -2599,18 +2597,6 @@ http://www.w3.org/TR/html401/struct/global.html
 			<regexp-list>
 				<regexp name="cssIdentifier"/>
 				<regexp name="integer"/>
-			</regexp-list>
-		</property>
-		<property name="clip" default="auto" description="The 'clip' property applies to elements that have a 'overflow' property with a value other than 'visible'.">
-			<category-list>
-				<category value="visual"/>
-			</category-list>
-			<literal-list>
-				<literal value="auto"/>			
-				<literal value="inherit"/>
-			</literal-list>
-			<regexp-list>
-				<regexp name="length"/>
 			</regexp-list>
 		</property>
 		<property name="cursor" default="auto" description="This property specifies the type of cursor to be displayed for the pointing device.">


### PR DESCRIPTION
- The "clip" property was duplicated.
- "col" tag had two definitions, one of them a plain validation action.

This PR fixes #53.