### PR TITLE
Add policy schema validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 .classpath
 .java-version
 
+antisamy.iml

--- a/src/main/java/org/owasp/validator/html/Policy.java
+++ b/src/main/java/org/owasp/validator/html/Policy.java
@@ -24,7 +24,7 @@
 
 package org.owasp.validator.html;
 
-import static org.owasp.validator.html.util.XMLUtil.getAttributeValue;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,7 +63,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import static org.owasp.validator.html.util.XMLUtil.getAttributeValue;
 
 /**
  * Policy.java - This file holds the model for our policy engine.

--- a/src/main/java/org/owasp/validator/html/Policy.java
+++ b/src/main/java/org/owasp/validator/html/Policy.java
@@ -75,7 +75,7 @@ public class Policy {
 
     public static final Pattern ANYTHING_REGEXP = Pattern.compile(".*");
 
-    private static final String POLICY_XSD_SCHEMA = "antisamy.xsd";
+    private static final String POLICY_SCHEMA_URI = "antisamy.xsd";
     protected static final String DEFAULT_POLICY_URI = "resources/antisamy.xml";
     private static final String DEFAULT_ONINVALID = "removeAttribute";
 
@@ -118,7 +118,6 @@ public class Policy {
      * XML Schema for policy validation
      */
     private static Schema schema = null;
-
 
     /**
      * Get the Tag specified by the provided tag name.
@@ -302,12 +301,7 @@ public class Policy {
 
     protected static Element getTopLevelElement(InputSource source) throws PolicyException {
         try {
-        	if (schema == null) {
-        		URI uri = Policy.class.getClassLoader().getResource(POLICY_XSD_SCHEMA).toURI();
-        		File file = new File (uri);
-        		schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
-        				.newSchema(file);
-        	}
+            getPolicySchema();
 
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 
@@ -389,12 +383,7 @@ public class Policy {
                 }
             }
 
-            if (schema == null) {
-                URI uri = Policy.class.getClassLoader().getResource(POLICY_XSD_SCHEMA).toURI();
-                File file = new File (uri);
-                schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
-                        .newSchema(file);
-            }
+            getPolicySchema();
 
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 
@@ -915,8 +904,20 @@ public class Policy {
         return commonRegularExpressions.get(name);
     }
 
-    static class SAXErrorHandler implements ErrorHandler {
+    private static void getPolicySchema() throws URISyntaxException, SAXException {
+        if (schema == null) {
+            URI uri = Policy.class.getClassLoader().getResource(POLICY_SCHEMA_URI).toURI();
+            File file = new File(uri);
+            schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+                    .newSchema(file);
+        }
+    }
 
+    /**
+     * This class is implemented to just throw exception when
+     * validating the policy schema while parsing the document.
+     */
+    static class SAXErrorHandler implements ErrorHandler {
 		@Override
 		public void error(SAXParseException arg0) throws SAXException {
 			throw arg0;
@@ -931,6 +932,5 @@ public class Policy {
 		public void warning(SAXParseException arg0) throws SAXException {
 			throw arg0;
 		}
-
     }
 }

--- a/src/main/java/org/owasp/validator/html/Policy.java
+++ b/src/main/java/org/owasp/validator/html/Policy.java
@@ -113,16 +113,16 @@ public class Policy {
 
     private final TagMatcher allowedEmptyTagsMatcher;
     private final TagMatcher requiresClosingTagsMatcher;
-    
+
     /**
      * XML Schema for policy validation
      */
-    private static Schema schema = null;    
-    
+    private static Schema schema = null;
+
 
     /**
      * Get the Tag specified by the provided tag name.
-     * 
+     *
      * @param tagName
      *            The name of the Tag to return.
      * @return The requested Tag, or null if it doesn't exist.
@@ -301,14 +301,14 @@ public class Policy {
     }
 
     protected static Element getTopLevelElement(InputSource source) throws PolicyException {
-        try {	
+        try {
         	if (schema == null) {
         		URI uri = Policy.class.getClassLoader().getResource(POLICY_XSD_SCHEMA).toURI();
         		File file = new File (uri);
         		schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
         				.newSchema(file);
         	}
-        	
+
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 
             /**
@@ -325,7 +325,7 @@ public class Policy {
             Document dom = db.parse(source);
 
             return dom.getDocumentElement();
-        } catch (URISyntaxException | SAXException | ParserConfigurationException | IOException e) {
+        } catch (SAXException | ParserConfigurationException | IOException | URISyntaxException e) {
             throw new PolicyException(e);
         }
     }
@@ -389,6 +389,13 @@ public class Policy {
                 }
             }
 
+            if (schema == null) {
+                URI uri = Policy.class.getClassLoader().getResource(POLICY_XSD_SCHEMA).toURI();
+                File file = new File (uri);
+                schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+                        .newSchema(file);
+            }
+
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 
             /**
@@ -398,7 +405,10 @@ public class Policy {
             dbf.setFeature(EXTERNAL_PARAM_ENTITIES, false);
             dbf.setFeature(DISALLOW_DOCTYPE_DECL, true);
             dbf.setFeature(LOAD_EXTERNAL_DTD, false);
+            dbf.setNamespaceAware(true);
+            dbf.setSchema(schema);
             DocumentBuilder db = dbf.newDocumentBuilder();
+            db.setErrorHandler(new SAXErrorHandler());
             Document dom;
 
             /**
@@ -415,7 +425,7 @@ public class Policy {
             }
 
             return null;
-        } catch (SAXException | ParserConfigurationException | IOException e) {
+        } catch (SAXException | ParserConfigurationException | IOException | URISyntaxException e) {
             throw new PolicyException(e);
         }
     }
@@ -811,7 +821,7 @@ public class Policy {
 
     /**
      * Resolves public and system IDs to files stored within the JAR.
-     * 
+     *
      * @param systemId The name of the entity we want to look up.
      * @param baseUrl The base location of the entity.
      * @return A String object containing the directive associated with the lookup name, or null if none is found.
@@ -919,8 +929,8 @@ public class Policy {
 
 		@Override
 		public void warning(SAXParseException arg0) throws SAXException {
-			throw arg0;			
+			throw arg0;
 		}
-    
+
     }
 }

--- a/src/main/resources/antisamy.xsd
+++ b/src/main/resources/antisamy.xsd
@@ -4,54 +4,54 @@
 	<xsd:element name="anti-samy-rules">
 		<xsd:complexType>
 			<xsd:sequence>
-				<xsd:element name="directives" type="Directives" maxOccurs="1" minOccurs="1"/>
-				<xsd:element name="common-regexps" type="CommonRegexps" maxOccurs="1" minOccurs="1"/>
-				<xsd:element name="common-attributes" type="AttributeList" maxOccurs="1" minOccurs="1"/>
-				<xsd:element name="global-tag-attributes" type="AttributeList" maxOccurs="1" minOccurs="1"/>
-				<xsd:element name="dynamic-tag-attributes" type="AttributeList" maxOccurs="1" minOccurs="1"/>
-				<xsd:element name="tags-to-encode" type="TagsToEncodeList" minOccurs="0" maxOccurs="1"/>
-				<xsd:element name="tag-rules" type="TagRules" minOccurs="1" maxOccurs="1"/>
-				<xsd:element name="css-rules" type="CSSRules" minOccurs="1" maxOccurs="1"/>
-	        	<xsd:element name="allowed-empty-tags" type="AllowedEmptyTags" minOccurs="0" maxOccurs="1"/>
+				<xsd:element name="directives" type="Directives"/>
+				<xsd:element name="common-regexps" type="CommonRegexps"/>
+				<xsd:element name="common-attributes" type="AttributeList"/>
+				<xsd:element name="global-tag-attributes" type="AttributeList"/>
+				<xsd:element name="dynamic-tag-attributes" type="AttributeList" minOccurs="0"/>
+				<xsd:element name="tags-to-encode" type="TagsToEncodeList" minOccurs="0"/>
+				<xsd:element name="tag-rules" type="TagRules"/>
+				<xsd:element name="css-rules" type="CSSRules"/>
+	        	<xsd:element name="allowed-empty-tags" type="AllowedEmptyTags" minOccurs="0"/>
 			</xsd:sequence>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:complexType name="Directives">
 		<xsd:sequence maxOccurs="unbounded">
 			<xsd:element name="directive" type="Directive" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="Directive">
 		<xsd:attribute name="name" use="required"/>
 		<xsd:attribute name="value" use="required"/>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="CommonRegexps">
 		<xsd:sequence maxOccurs="unbounded">
 			<xsd:element name="regexp" type="RegExp" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="AttributeList">
 		<xsd:sequence maxOccurs="unbounded">
 			<xsd:element name="attribute" type="Attribute" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="TagsToEncodeList">
 		<xsd:sequence maxOccurs="unbounded">
 			<xsd:element name="tag" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="TagRules">
 		<xsd:sequence maxOccurs="unbounded">
 			<xsd:element name="tag" type="Tag" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="Tag">
 		<xsd:sequence maxOccurs="unbounded">
 			<xsd:element name="attribute" type="Attribute" minOccurs="0" />
@@ -62,7 +62,7 @@
 
     <xsd:complexType name="AllowedEmptyTags">
         <xsd:sequence>
-            <xsd:element name="literal-list" type="LiteralList" minOccurs="1"/>
+            <xsd:element name="literal-list" type="LiteralList" minOccurs="0"/>
         </xsd:sequence>
     </xsd:complexType>
 
@@ -96,13 +96,13 @@
 	<xsd:complexType name="Literal">
 		<xsd:attribute name="value" type="xsd:string"/>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="CSSRules">
 		<xsd:sequence maxOccurs="unbounded">
 			<xsd:element name="property" type="Property" minOccurs="0"/>
-		</xsd:sequence>		
+		</xsd:sequence>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="Property">
 		<xsd:sequence>
 			<xsd:element name="category-list" type="CategoryList" minOccurs="0"/>
@@ -123,7 +123,7 @@
 
 	<xsd:complexType name="Shorthand">
 		<xsd:attribute name="name" type="xsd:string" use="required"/>
-	</xsd:complexType>	
+	</xsd:complexType>
 
 	<xsd:complexType name="CategoryList">
 		<xsd:sequence maxOccurs="unbounded">
@@ -136,7 +136,7 @@
 	</xsd:complexType>
 
 	<xsd:complexType name="Entity">
-		<xsd:attribute name="name" type="xsd:string" use="required"/>	
+		<xsd:attribute name="name" type="xsd:string" use="required"/>
 		<xsd:attribute name="cdata" type="xsd:string" use="required"/>
 	</xsd:complexType>
 </xsd:schema>

--- a/src/test/java/org/owasp/validator/html/test/PolicyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/PolicyTest.java
@@ -86,18 +86,35 @@ public class PolicyTest extends TestCase {
         assertTrue(policy.getAllowedEmptyTags().size() == Constants.defaultAllowedEmptyTags.size());
     }
     
-    public void testInvalidPolicy() throws PolicyException {
-        String allowedEmptyTagsSection = "<notSupportedTag>\n" +
+    public void testInvalidPolicies() {
+        String notSupportedTagsSection = "<notSupportedTag>\n" +
                                          "</notSupportedTag>\n";
-        String policyFile = assembleFile(allowedEmptyTagsSection);
+        String policyFile = assembleFile(notSupportedTagsSection);
         try {
 			policy = Policy.getInstance(new ByteArrayInputStream(policyFile.getBytes()));
-	        fail("Not supported tag on policy, but not PolicyException Ocurred");
+	        fail("Not supported tag on policy, but not PolicyException occurred.");
 		} catch (PolicyException e) {
 			assertNotNull(e);
 		}
 
-    }
+        String duplicatedTagsSection = "<tag-rules>\n" +
+                                       "</tag-rules>\n";
+        policyFile = assembleFile(duplicatedTagsSection);
+        try {
+            policy = Policy.getInstance(new ByteArrayInputStream(policyFile.getBytes()));
+            fail("<tag-rules> is duplicated but it should not be, PolicyException was expected.");
+        } catch (PolicyException e) {
+            assertNotNull(e);
+        }
 
-    
+        policyFile = assembleFile(duplicatedTagsSection)
+                .replace("<tag-rules>", "")
+                .replace("</tag-rules>", "");
+        try {
+            policy = Policy.getInstance(new ByteArrayInputStream(policyFile.getBytes()));
+            fail("<tag-rules> is missing but it should not be, PolicyException was expected.");
+        } catch (PolicyException e) {
+            assertNotNull(e);
+        }
+    }
 }

--- a/src/test/java/org/owasp/validator/html/test/PolicyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/PolicyTest.java
@@ -107,7 +107,7 @@ public class PolicyTest extends TestCase {
             assertNotNull(e);
         }
 
-        policyFile = assembleFile(duplicatedTagsSection)
+        policyFile = assembleFile("")
                 .replace("<tag-rules>", "")
                 .replace("</tag-rules>", "");
         try {

--- a/src/test/java/org/owasp/validator/html/test/PolicyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/PolicyTest.java
@@ -85,4 +85,19 @@ public class PolicyTest extends TestCase {
 
         assertTrue(policy.getAllowedEmptyTags().size() == Constants.defaultAllowedEmptyTags.size());
     }
+    
+    public void testInvalidPolicy() throws PolicyException {
+        String allowedEmptyTagsSection = "<notSupportedTag>\n" +
+                                         "</notSupportedTag>\n";
+        String policyFile = assembleFile(allowedEmptyTagsSection);
+        try {
+			policy = Policy.getInstance(new ByteArrayInputStream(policyFile.getBytes()));
+	        fail("Not supported tag on policy, but not PolicyException Ocurred");
+		} catch (PolicyException e) {
+			assertNotNull(e);
+		}
+
+    }
+
+    
 }


### PR DESCRIPTION
As a solution to issue #58:

- Policy schema validation was added using the only defined XSD file.
- Exception is thrown when policy does not respect the schema definition.
- Schema definition was updated to accept valid policies that were not validating before:
  - `<dynamic-tag-attributes>` absence allowed.
  - `<literal-list absence>` allowed on `AllowedEmptyTags` type.
- Some attributes occurrences were trimmed as they were not really necessary, to improve readability.
- Three test cases were added for different cases of invalid policies.

This changes resulted from the OWASP Uruguay chapter on a collaboration day. Participants:
- @gerardocanedo 
- @martinmarsicano
- @spassarop 