### PR TITLE
Add toggle for policy validation

### DIFF
--- a/src/test/java/org/owasp/validator/html/test/PolicyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/PolicyTest.java
@@ -115,7 +115,7 @@ public class PolicyTest extends TestCase {
         String policyFile = assembleFile(notSupportedTagsSection);
         try {
             policy = Policy.getInstance(new ByteArrayInputStream(policyFile.getBytes()));
-            fail("Not supported tag on policy, but not PolicyException occurred.");
+            fail("Not supported tag on policy, but no PolicyException occurred.");
         } catch (PolicyException e) {
             assertNotNull(e);
         }
@@ -136,6 +136,32 @@ public class PolicyTest extends TestCase {
         try {
             policy = Policy.getInstance(new ByteArrayInputStream(policyFile.getBytes()));
             fail("<tag-rules> is missing but it should not be, PolicyException was expected.");
+        } catch (PolicyException e) {
+            assertNotNull(e);
+        }
+    }
+
+    public void testSchemaValidationToggle() {
+        String notSupportedTagsSection = "<notSupportedTag>\n" +
+                "</notSupportedTag>\n";
+        String policyFile = assembleFile(notSupportedTagsSection);
+
+        // Disable validation
+        Policy.toggleSchemaValidation(false);
+
+        try {
+            policy = Policy.getInstance(new ByteArrayInputStream(policyFile.getBytes()));
+            assertNotNull(policy);
+        } catch (PolicyException e) {
+            fail("Not supported tag on policy, but not PolicyException occurred.");
+        }
+
+        // Enable validation again
+        Policy.toggleSchemaValidation(true);
+
+        try {
+            policy = Policy.getInstance(new ByteArrayInputStream(policyFile.getBytes()));
+            fail("Not supported tag on policy, but no PolicyException occurred.");
         } catch (PolicyException e) {
             assertNotNull(e);
         }

--- a/src/test/java/org/owasp/validator/html/test/PolicyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/PolicyTest.java
@@ -35,6 +35,7 @@ import org.owasp.validator.html.TagMatcher;
 import org.owasp.validator.html.scan.Constants;
 
 import java.io.ByteArrayInputStream;
+import java.net.URL;
 
 /**
  * This class tests the Policy functionality to show that we can successfully parse the policy file.
@@ -141,7 +142,7 @@ public class PolicyTest extends TestCase {
         }
     }
 
-    public void testSchemaValidationToggle() {
+    public void testSchemaValidationToggleWithSource() {
         String notSupportedTagsSection = "<notSupportedTag>\n" +
                 "</notSupportedTag>\n";
         String policyFile = assembleFile(notSupportedTagsSection);
@@ -156,11 +157,52 @@ public class PolicyTest extends TestCase {
             fail("Schema validation is disabled, policy creation should not fail.");
         }
 
+        // This one should only print a warning on the console because validation is disabled
+        try {
+            policy = Policy.getInstance(new ByteArrayInputStream(assembleFile("").getBytes()));
+            assertNotNull(policy);
+        } catch (PolicyException e) {
+            fail("Schema validation is disabled, policy creation should not fail.");
+        }
+
         // Enable validation again
         Policy.toggleSchemaValidation(true);
 
         try {
             policy = Policy.getInstance(new ByteArrayInputStream(policyFile.getBytes()));
+            fail("Not supported tag on policy, but no PolicyException occurred.");
+        } catch (PolicyException e) {
+            assertNotNull(e);
+        }
+    }
+
+    public void testSchemaValidationToggleWithUrl() {
+        URL urlOfValidPolicy = getClass().getResource("/antisamy.xml");
+        URL urlOfInvalidPolicy = getClass().getResource("/invalidPolicy.xml");
+
+        // Disable validation
+        Policy.toggleSchemaValidation(false);
+
+        try {
+            policy = TestPolicy.getInstance(urlOfInvalidPolicy);
+            assertNotNull(policy);
+        } catch (PolicyException e) {
+            fail("Schema validation is disabled, policy creation should not fail.");
+        }
+
+        // This one should only print a warning on the console because validation is disabled
+        try {
+            policy = TestPolicy.getInstance(urlOfValidPolicy);
+            assertNotNull(policy);
+        } catch (PolicyException e) {
+            fail("Schema validation is disabled, policy creation should not fail.");
+        }
+
+        // Enable validation again
+        Policy.toggleSchemaValidation(true);
+
+        try {
+            policy = TestPolicy.getInstance(urlOfInvalidPolicy);
             fail("Not supported tag on policy, but no PolicyException occurred.");
         } catch (PolicyException e) {
             assertNotNull(e);

--- a/src/test/java/org/owasp/validator/html/test/PolicyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/PolicyTest.java
@@ -153,7 +153,7 @@ public class PolicyTest extends TestCase {
             policy = Policy.getInstance(new ByteArrayInputStream(policyFile.getBytes()));
             assertNotNull(policy);
         } catch (PolicyException e) {
-            fail("Not supported tag on policy, but not PolicyException occurred.");
+            fail("Schema validation is disabled, policy creation should not fail.");
         }
 
         // Enable validation again

--- a/src/test/resources/invalidPolicy.xml
+++ b/src/test/resources/invalidPolicy.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<anti-samy-rules xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="antisamy.xsd">
+	<directives></directives>
+	<common-regexps></common-regexps>
+	<common-attributes></common-attributes>
+	<global-tag-attributes></global-tag-attributes>
+	<dynamic-tag-attributes></dynamic-tag-attributes>
+	<tag-rules></tag-rules>
+	<css-rules></css-rules>
+	<notSupportedTag></notSupportedTag>
+</anti-samy-rules>


### PR DESCRIPTION
- New static method on Policy to enable/disable schema validation. It's enabled by default.
- Test added.
- Removed unnecesary exception catch for code that was removed.
- 
Just for the record, this is related to issue #58.