### PR TITLE
Adding <include> tag  for policy validation

### DIFF
--- a/src/main/java/org/owasp/validator/html/Policy.java
+++ b/src/main/java/org/owasp/validator/html/Policy.java
@@ -207,8 +207,8 @@ public class Policy {
      * @throws PolicyException If there is a problem parsing the input stream.
      */
     public static Policy getInstance(InputStream inputStream) throws PolicyException {
+        logger.info("Attempting to load policy from an input stream");
         return new InternalPolicy(null, getSimpleParseContext(getTopLevelElement(inputStream)));
-
     }
 
     /**
@@ -238,6 +238,7 @@ public class Policy {
      * @throws PolicyException If the file is not found or there is a problem parsing the file.
      */
     public static Policy getInstance(URL url) throws PolicyException {
+        logger.info("Attempting to load policy from URL: " + url.toString());
         return new InternalPolicy(url, getParseContext(getTopLevelElement(url), url));
     }
 
@@ -466,6 +467,9 @@ public class Policy {
 
             try {
                 url = new URL(baseUrl, href);
+
+                logger.info("Attempting to load policy from URL: " + url.toString());
+
                 source = new InputSource(url.openStream());
                 source.setSystemId(href);
 

--- a/src/main/resources/antisamy.xsd
+++ b/src/main/resources/antisamy.xsd
@@ -4,6 +4,7 @@
 	<xsd:element name="anti-samy-rules">
 		<xsd:complexType>
 			<xsd:sequence>
+				<xsd:element name="include" type="Include" minOccurs="0" maxOccurs="unbounded"/>
 				<xsd:element name="directives" type="Directives"/>
 				<xsd:element name="common-regexps" type="CommonRegexps"/>
 				<xsd:element name="common-attributes" type="AttributeList"/>
@@ -16,6 +17,10 @@
 			</xsd:sequence>
 		</xsd:complexType>
 	</xsd:element>
+
+	<xsd:complexType name="Include">
+		<xsd:attribute name="href" use="required" type="xsd:string"/>
+	</xsd:complexType>
 
 	<xsd:complexType name="Directives">
 		<xsd:sequence maxOccurs="unbounded">

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Root level="warn">
+    <Root level="info">
       <AppenderRef ref="Console"/>
     </Root>
   </Loggers>

--- a/src/test/java/org/owasp/validator/html/test/PolicyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/PolicyTest.java
@@ -210,5 +210,31 @@ public class PolicyTest extends TestCase {
             assertNotNull(e);
         }
     }
+
+    public void testSchemaValidationToggleWithInclude() {
+        // This policy will also include invalidPolicy.xml
+        URL url = getClass().getResource("/emptyPolicyWithInclude.xml");
+
+        // Disable validation
+        Policy.setSchemaValidation(false);
+
+        try {
+            System.out.println("TESTING: A schema invalid WARNING should follow:");
+            policy = TestPolicy.getInstance(url);
+            assertNotNull(policy);
+        } catch (PolicyException e) {
+            fail("Policy creation should not fail for invalid policy when schema validation disabled.");
+        }
+
+        // Enable validation again
+        Policy.setSchemaValidation(true);
+
+        try {
+            policy = TestPolicy.getInstance(url);
+            fail("PolicyException not thrown for policy w/invalid schema and schema validation enabled.");
+        } catch (PolicyException e) {
+            assertNotNull(e);
+        }
+    }
 }
 

--- a/src/test/resources/emptyPolicyWithInclude.xml
+++ b/src/test/resources/emptyPolicyWithInclude.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<anti-samy-rules xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="antisamy.xsd">
+	<include href="invalidPolicy.xml"/>
+	<directives></directives>
+	<common-regexps></common-regexps>
+	<common-attributes></common-attributes>
+	<global-tag-attributes></global-tag-attributes>
+	<dynamic-tag-attributes></dynamic-tag-attributes>
+	<tag-rules></tag-rules>
+	<css-rules></css-rules>
+</anti-samy-rules>

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -6,7 +6,7 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Root level="warn">
+    <Root level="info">
       <AppenderRef ref="Console"/>
     </Root>
   </Loggers>


### PR DESCRIPTION
- Updated XSD to have `<include>` tags on the beginning. This way policies that include others still work.
- Added an empty policy and a test for validation enabling/desabling which has `<include>`, the case left without testing before.
- Add info level logging to specify if the source of the policy is a stream or a file URL. In the second case, the URL is displayed.
