### PR TITLE
Override URL encoding when serializing results to HTML

### DIFF
--- a/src/main/java/org/owasp/validator/html/scan/ASHTMLSerializer.java
+++ b/src/main/java/org/owasp/validator/html/scan/ASHTMLSerializer.java
@@ -4,6 +4,8 @@ import org.apache.xml.serialize.ElementState;
 import org.apache.xml.serialize.HTMLdtd;
 import org.apache.xml.serialize.OutputFormat;
 import org.owasp.validator.html.InternalPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -11,6 +13,7 @@ import java.io.Writer;
 @SuppressWarnings("deprecation")
 public class ASHTMLSerializer extends org.apache.xml.serialize.HTMLSerializer {
 
+	private static final Logger logger = LoggerFactory.getLogger(ASHTMLSerializer.class);
 	private boolean encodeAllPossibleEntities;
 
     public ASHTMLSerializer(Writer w, OutputFormat format, InternalPolicy policy) {
@@ -67,4 +70,14 @@ public class ASHTMLSerializer extends org.apache.xml.serialize.HTMLSerializer {
 			_printer.flush();
 	}
 
+	@Override
+	protected String escapeURI(String uri) {
+    	String originalURI = uri;
+		try {
+			printEscaped(uri);
+		} catch (IOException e) {
+			logger.error("URI escaping failed for value: " + originalURI);
+		}
+		return "";
+	}
 }

--- a/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
@@ -1490,5 +1490,15 @@ static final String test33 = "<html>\n"
         assertThat(as.scan("<p style=\"color: red\">Some Text</p>", policy, AntiSamy.DOM).getCleanHTML(), not(containsString("!important")));
         assertThat(as.scan("<p style=\"color: red\">Some Text</p>", policy, AntiSamy.SAX).getCleanHTML(), not(containsString("!important")));
     }
+
+    @Test
+    public void entityReferenceEncodedInHtmlAttribute() throws ScanException, PolicyException {
+        // Concern is that "&" is not being encoded and "#00058" was not being interpreted as ":"
+        // so the validations based on regexp passed and a browser would load "&:" together
+        assertThat(as.scan("<p><a href=\"javascript&#00058x=1,%61%6c%65%72%74%28%22%62%6f%6f%6d%22%29\">xss</a></p>", policy, AntiSamy.DOM).getCleanHTML(),
+                containsString("javascript&amp;#00058"));
+        assertThat(as.scan("<p><a href=\"javascript&#00058x=1,%61%6c%65%72%74%28%22%62%6f%6f%6d%22%29\">xss</a></p>", policy, AntiSamy.SAX).getCleanHTML(),
+                containsString("javascript&amp;#00058"));
+    }
 }
 

--- a/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
@@ -1494,10 +1494,12 @@ static final String test33 = "<html>\n"
     @Test
     public void entityReferenceEncodedInHtmlAttribute() throws ScanException, PolicyException {
         // Concern is that "&" is not being encoded and "#00058" was not being interpreted as ":"
-        // so the validations based on regexp passed and a browser would load "&:" together
-        assertThat(as.scan("<p><a href=\"javascript&#00058x=1,%61%6c%65%72%74%28%22%62%6f%6f%6d%22%29\">xss</a></p>", policy, AntiSamy.DOM).getCleanHTML(),
+        // so the validations based on regexp passed and a browser would load "&:" together.
+        // All this when not using the XHTML serializer.
+        Policy revised = policy.cloneWithDirective("useXHTML","false");
+        assertThat(as.scan("<p><a href=\"javascript&#00058x=1,%61%6c%65%72%74%28%22%62%6f%6f%6d%22%29\">xss</a></p>", revised, AntiSamy.DOM).getCleanHTML(),
                 containsString("javascript&amp;#00058"));
-        assertThat(as.scan("<p><a href=\"javascript&#00058x=1,%61%6c%65%72%74%28%22%62%6f%6f%6d%22%29\">xss</a></p>", policy, AntiSamy.SAX).getCleanHTML(),
+        assertThat(as.scan("<p><a href=\"javascript&#00058x=1,%61%6c%65%72%74%28%22%62%6f%6f%6d%22%29\">xss</a></p>", revised, AntiSamy.SAX).getCleanHTML(),
                 containsString("javascript&amp;#00058"));
     }
 }


### PR DESCRIPTION
When serializing results to HTML, URLs are not being encoded when they are on HTML attributes. This could lead to mistakes when validating values. If URLs are HTML-encoded then they would work when rendered and potentially malicious payloads will fail after encoding.

A test case was added (for DOM and SAX) testing this problem.