### PR TITLE
fix: policy.getInstance could not find the default antisamy policy file

### DIFF
--- a/src/main/java/org/owasp/validator/html/Policy.java
+++ b/src/main/java/org/owasp/validator/html/Policy.java
@@ -125,7 +125,7 @@ public class Policy {
     public static final Pattern ANYTHING_REGEXP = Pattern.compile(".*", Pattern.DOTALL);
 
     private static final String POLICY_SCHEMA_URI = "antisamy.xsd";
-    protected static final String DEFAULT_POLICY_URI = "resources/antisamy.xml";
+    protected static final String DEFAULT_POLICY_URI = "antisamy.xml";
     private static final String DEFAULT_ONINVALID = "removeAttribute";
 
     public static final int DEFAULT_MAX_INPUT_SIZE = 100000;
@@ -254,13 +254,13 @@ public class Policy {
     }
 
     /**
-     * Construct a Policy using the default policy file location ("resources/antisamy.xml").
+     * Construct a Policy using the default policy file location ("antisamy.xml").
      *
      * @return A populated Policy object based on the XML policy file located in the default location.
      * @throws PolicyException If the file is not found or there is a problem parsing the file.
      */
     public static Policy getInstance() throws PolicyException {
-        return getInstance(DEFAULT_POLICY_URI);
+        return getInstance(Policy.class.getClassLoader().getResource(DEFAULT_POLICY_URI));
     }
 
     /**

--- a/src/test/java/org/owasp/validator/html/test/TestPolicy.java
+++ b/src/test/java/org/owasp/validator/html/test/TestPolicy.java
@@ -51,7 +51,7 @@ public class TestPolicy extends InternalPolicy {
     }
 
     public static TestPolicy getInstance() throws PolicyException {
-        return getInstance(DEFAULT_POLICY_URI);
+        return getInstance(Policy.class.getClassLoader().getResource(DEFAULT_POLICY_URI));
     }
 
     public static TestPolicy getInstance(String filename) throws PolicyException {


### PR DESCRIPTION
# Environment

windows jdk-8 maven 3.6.3  antisamy 1.6.4

# Steps to reproduce

```
Policy policy = Policy.getInstance();
AntiSamy as = new AntiSamy();
System.out.println(as.scan("<a i href=javascript:[1].find(alert)>CLICKHERE </a>", policy).getCleanHTML());
```

# What is expected?

the clean, safe HTML output.

# What is actually happening?

```
Caused by: java.io.FileNotFoundException: D:\.....\resources\antisamy.xml (...)
	at java.io.FileInputStream.open(Native Method)
	at java.io.FileInputStream.<init>(FileInputStream.java:146)
	at java.io.FileInputStream.<init>(FileInputStream.java:101)
	....
```

# Reason

```
protected static final String DEFAULT_POLICY_URI = "resources/antisamy.xml"
File file = new File(DEFAULT_POLICY_URI);
```

The default path is not to the Jar file.

# Solution

Use ClassLoader, as this PR, to get the resource files for the jar package.