### PR TITLE
refactor: partially invalid exception thrown

### DIFF
--- a/src/main/java/org/owasp/validator/html/AntiSamy.java
+++ b/src/main/java/org/owasp/validator/html/AntiSamy.java
@@ -67,11 +67,6 @@ public class AntiSamy {
 	 * @throws PolicyException When there is a problem reading the policy file.
 	 */
 	public CleanResults scan(String taintedHTML) throws ScanException, PolicyException {
-
-		if (policy == null) {
-			throw new PolicyException("No policy loaded");
-		}
-
 		return this.scan(taintedHTML, this.policy, SAX);
 	}
 
@@ -88,9 +83,6 @@ public class AntiSamy {
 	 */
 	public CleanResults scan(String taintedHTML, int scanType) throws ScanException, PolicyException {
 
-		if (policy == null) {
-			throw new PolicyException("No policy loaded");
-		}
 		return this.scan(taintedHTML, this.policy, scanType);
 	}
 
@@ -106,7 +98,7 @@ public class AntiSamy {
 	 * @throws PolicyException When there is a problem reading the policy file.
 	 */
 	public CleanResults scan(String taintedHTML, Policy policy) throws ScanException, PolicyException {
-		return new AntiSamyDOMScanner(policy).scan(taintedHTML);
+		return this.scan(taintedHTML, policy, DOM);
 	}
 
 	/**
@@ -122,6 +114,9 @@ public class AntiSamy {
 	 * @throws PolicyException When there is a problem reading the policy file.
 	 */
 	public CleanResults scan(String taintedHTML, Policy policy, int scanType) throws ScanException, PolicyException {
+		if (policy == null) {
+			throw new PolicyException("No policy loaded");
+		}
 
 		if (scanType == DOM) {
 			return new AntiSamyDOMScanner(policy).scan(taintedHTML);

--- a/src/main/java/org/owasp/validator/html/InternalPolicy.java
+++ b/src/main/java/org/owasp/validator/html/InternalPolicy.java
@@ -30,7 +30,7 @@ public class InternalPolicy extends Policy {
     private final boolean allowDynamicAttributes;
 
 
-    protected InternalPolicy(ParseContext parseContext) throws PolicyException {
+    protected InternalPolicy(ParseContext parseContext) {
         super(parseContext);
         this.maxInputSize = determineMaxInputSize();
         this.isNofollowAnchors = isTrue(Policy.ANCHORS_NOFOLLOW);

--- a/src/main/java/org/owasp/validator/html/Policy.java
+++ b/src/main/java/org/owasp/validator/html/Policy.java
@@ -329,7 +329,7 @@ public class Policy {
         return new InternalPolicy(getParseContext(getTopLevelElement(url), url));
     }
 
-    protected Policy(ParseContext parseContext) throws PolicyException {
+    protected Policy(ParseContext parseContext) {
         this.allowedEmptyTagsMatcher = new TagMatcher(parseContext.allowedEmptyTags);
         this.requiresClosingTagsMatcher = new TagMatcher(parseContext.requireClosingTags);
         this.commonRegularExpressions = Collections.unmodifiableMap(parseContext.commonRegularExpressions);
@@ -657,7 +657,7 @@ public class Policy {
      * @param allowedEmptyTags         The tags that can be empty
      */
     private static void parseAllowedEmptyTags(Element allowedEmptyTagsListNode,
-                                              List<String> allowedEmptyTags) throws PolicyException {
+                                              List<String> allowedEmptyTags) {
         if (allowedEmptyTagsListNode != null) {
             for (Element literalNode :
                     getGrandChildrenByTagName(allowedEmptyTagsListNode, "literal-list", "literal")) {
@@ -677,7 +677,7 @@ public class Policy {
      * @param requireClosingTags         The list of tags that require closing
      */
     private static void parseRequireClosingTags(Element requireClosingTagsListNode,
-                                                 List<String> requireClosingTags) throws PolicyException {
+                                                 List<String> requireClosingTags) {
         if (requireClosingTagsListNode != null) {
             for (Element literalNode :
                     getGrandChildrenByTagName(requireClosingTagsListNode, "literal-list", "literal")) {

--- a/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
+++ b/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
@@ -680,11 +680,7 @@ public class AntiSamyDOMScanner extends AbstractAntiSamyScanner {
 	private boolean isAllowedEmptyTag(String tagName) {
         return "head".equals(tagName ) || policy.getAllowedEmptyTags().matches(tagName);
 	}
-
-    public static void main(String[] args) throws PolicyException {
-    }
-
-
+	
     /**
      * Used to promote the children of a parent to accomplish the "filterTag" action.
      *


### PR DESCRIPTION
1, Remove useless `PolicyException`
2, The `PolicyException` thrown is meaningful after the custom policy parameter is judged null