### PR TITLE
Support common CSS relative length units such as rem, vw, vh, etc

### DIFF
--- a/src/main/resources/antisamy-anythinggoes.xml
+++ b/src/main/resources/antisamy-anythinggoes.xml
@@ -102,8 +102,8 @@ http://www.w3.org/TR/html401/struct/global.html
 		<regexp name="angle" value="(-|\+)?([0-9]+(\.[0-9]+)?)(deg|grads|rad)"/>
 		<regexp name="time" value="([0-9]+(\.[0-9]+)?)(ms|s)"/>
 		<regexp name="frequency" value="([0-9]+(\.[0-9]+)?)(hz|khz)"/>
-		<regexp name="length" value="((-|\+)?0|(-|\+)?([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)(em|ex|px|in|cm|mm|pt|pc))"/>
-		<regexp name="positiveLength" value="((\+)?0|(\+)?([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)(em|ex|px|in|cm|mm|pt|pc))"/>
+		<regexp name="length" value="((-|\+)?0|(-|\+)?([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)(rem|vw|vh|em|ex|px|in|cm|mm|pt|pc))"/>
+		<regexp name="positiveLength" value="((\+)?0|(\+)?([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)(rem|vw|vh|em|ex|px|in|cm|mm|pt|pc))"/>
 		<regexp name="percentage" value="(-|\+)?([0-9]+(\.[0-9]+)?)%"/>
 		<regexp name="positivePercentage" value="(\+)?([0-9]+(\.[0-9]+)?)%"/>
 

--- a/src/main/resources/antisamy-ebay.xml
+++ b/src/main/resources/antisamy-ebay.xml
@@ -100,8 +100,8 @@ http://www.w3.org/TR/html401/struct/global.html
 		<regexp name="angle" value="(-|\+)?([0-9]+(\.[0-9]+)?)(deg|grads|rad)"/>
 		<regexp name="time" value="([0-9]+(\.[0-9]+)?)(ms|s)"/>
 		<regexp name="frequency" value="([0-9]+(\.[0-9]+)?)(hz|khz)"/>
-		<regexp name="length" value="((-|\+)?0|(-|\+)?([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)(em|ex|px|in|cm|mm|pt|pc))"/>
-		<regexp name="positiveLength" value="((\+)?0|(\+)?([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)(em|ex|px|in|cm|mm|pt|pc))"/>
+		<regexp name="length" value="((-|\+)?0|(-|\+)?([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)(rem|vw|vh|em|ex|px|in|cm|mm|pt|pc))"/>
+		<regexp name="positiveLength" value="((\+)?0|(\+)?([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)(rem|vw|vh|em|ex|px|in|cm|mm|pt|pc))"/>
 		<regexp name="percentage" value="(-|\+)?([0-9]+(\.[0-9]+)?)%"/>
 		<regexp name="positivePercentage" value="(\+)?([0-9]+(\.[0-9]+)?)%"/>
 

--- a/src/main/resources/antisamy-myspace.xml
+++ b/src/main/resources/antisamy-myspace.xml
@@ -102,8 +102,8 @@ http://www.w3.org/TR/html401/struct/global.html
 		<regexp name="angle" value="(-|\+)?([0-9]+(\.[0-9]+)?)(deg|grads|rad)"/>
 		<regexp name="time" value="([0-9]+(\.[0-9]+)?)(ms|s)"/>
 		<regexp name="frequency" value="([0-9]+(\.[0-9]+)?)(hz|khz)"/>
-		<regexp name="length" value="((-|\+)?0|(-|\+)?([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)(em|ex|px|in|cm|mm|pt|pc))"/>
-		<regexp name="positiveLength" value="((\+)?0|(\+)?([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)(em|ex|px|in|cm|mm|pt|pc))"/>
+		<regexp name="length" value="((-|\+)?0|(-|\+)?([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)(rem|vw|vh|em|ex|px|in|cm|mm|pt|pc))"/>
+		<regexp name="positiveLength" value="((\+)?0|(\+)?([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)(rem|vw|vh|em|ex|px|in|cm|mm|pt|pc))"/>
 		<regexp name="percentage" value="(-|\+)?([0-9]+(\.[0-9]+)?)%"/>
 		<regexp name="positivePercentage" value="(\+)?([0-9]+(\.[0-9]+)?)%"/>
 

--- a/src/main/resources/antisamy.xml
+++ b/src/main/resources/antisamy.xml
@@ -106,9 +106,9 @@ http://www.w3.org/TR/html401/struct/global.html
 		<regexp name="number" value="(-|\+)?([0-9]+(\.[0-9]+)?)"/>
 		<regexp name="angle" value="(-|\+)?([0-9]+(\.[0-9]+)?)(deg|grads|rad)"/>
 		<regexp name="time" value="([0-9]+(\.[0-9]+)?)(ms|s)"/>
-		<regexp name="frequency" value="([0-9]+(\.[0-9]+)?)(hz|khz)"/>	
-		<regexp name="length" value="((-|\+)?0|(-|\+)?([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)(em|ex|px|in|cm|mm|pt|pc))"/>
-		<regexp name="positiveLength" value="((\+)?0|(\+)?([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)(em|ex|px|in|cm|mm|pt|pc))"/>
+		<regexp name="frequency" value="([0-9]+(\.[0-9]+)?)(hz|khz)"/>
+		<regexp name="length" value="((-|\+)?0|(-|\+)?([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)(rem|vw|vh|em|ex|px|in|cm|mm|pt|pc))"/>
+		<regexp name="positiveLength" value="((\+)?0|(\+)?([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)(rem|vw|vh|em|ex|px|in|cm|mm|pt|pc))"/>
 		<regexp name="percentage" value="(-|\+)?([0-9]+(\.[0-9]+)?)%"/>
 		<regexp name="positivePercentage" value="(\+)?([0-9]+(\.[0-9]+)?)%"/>
 		

--- a/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
@@ -1527,5 +1527,26 @@ static final String test33 = "<html>\n"
         assertThat(as.scan("<p style=\"margin: 1.0E+4pt;\">Some text.</p>", policy, AntiSamy.DOM).getCleanHTML(), not(containsString("margin")));
         assertThat(as.scan("<p style=\"margin: 1.0E+4pt;\">Some text.</p>", policy, AntiSamy.SAX).getCleanHTML(), not(containsString("margin")));
     }
+
+    @Test
+    public void testCSSUnits() throws ScanException, PolicyException {
+        String input = "<div style=\"width:50vw;height:50vh;padding:1rpc;\">\n" +
+                "\t<p style=\"font-size:1.5ex;padding-left:1rem;padding-top:16px;\">Some text.</p>\n" +
+                "</div>";
+        CleanResults cr = as.scan(input, policy, AntiSamy.DOM);
+        assertThat(cr.getCleanHTML(), containsString("ex"));
+        assertThat(cr.getCleanHTML(), containsString("px"));
+        assertThat(cr.getCleanHTML(), containsString("rem"));
+        assertThat(cr.getCleanHTML(), containsString("vw"));
+        assertThat(cr.getCleanHTML(), containsString("vh"));
+        assertThat(cr.getCleanHTML(), not(containsString("rpc")));
+        cr = as.scan(input, policy, AntiSamy.SAX);
+        assertThat(cr.getCleanHTML(), containsString("ex"));
+        assertThat(cr.getCleanHTML(), containsString("px"));
+        assertThat(cr.getCleanHTML(), containsString("rem"));
+        assertThat(cr.getCleanHTML(), containsString("vw"));
+        assertThat(cr.getCleanHTML(), containsString("vh"));
+        assertThat(cr.getCleanHTML(), not(containsString("rpc")));
+    }
 }
 


### PR DESCRIPTION
## Reason
```
<p style="width: 13rem;">This is text.</p>
Out 
<p style="">This is text.</p>
```
Want to support all [relative length units](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units)?