### PR TITLE
Remove SLF4J binding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,12 @@
             <artifactId>slf4j-api</artifactId>
             <version>${version.slf4j}</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${version.slf4j}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- While Java 7+ includes Xerces in the JRE, it apparently doesn't provide all the features we use
              that are in the Apache version. So we import it directly. -->
         <dependency>


### PR DESCRIPTION
See http://www.slf4j.org/manual.html#libraries

```
BASIC RULE Embedded components such as libraries or frameworks should not declare a dependency on any SLF4J binding
 but only depend on slf4j-api. When a library declares a transitive dependency on a specific binding, that binding is imposed
  |on the end-user negating the purpose of SLF4J. Note that declaring a non-transitive dependency on a binding, for example 
 for testing, does not affect the end-user.
```