### PR TITLE
Policy xml files: Change angle unit: grads->grad

### DIFF
--- a/src/main/resources/antisamy-anythinggoes.xml
+++ b/src/main/resources/antisamy-anythinggoes.xml
@@ -99,7 +99,7 @@ http://www.w3.org/TR/html401/struct/global.html
 		<regexp name="integer" value="(-|\+)?[0-9]+"/>
 		<regexp name="positiveInteger" value="(\+)?[0-9]+"/>
 		<regexp name="number" value="(-|\+)?([0-9]+(\.[0-9]+)?)"/>
-		<regexp name="angle" value="(-|\+)?([0-9]+(\.[0-9]+)?)(deg|grads|rad)"/>
+		<regexp name="angle" value="(-|\+)?([0-9]+(\.[0-9]+)?)(deg|grad|rad)"/>
 		<regexp name="time" value="([0-9]+(\.[0-9]+)?)(ms|s)"/>
 		<regexp name="frequency" value="([0-9]+(\.[0-9]+)?)(hz|khz)"/>
 		<regexp name="length" value="((-|\+)?0|(-|\+)?([0-9]+(\.[0-9]+)?)(em|ex|px|in|cm|mm|pt|pc))"/>

--- a/src/main/resources/antisamy-ebay.xml
+++ b/src/main/resources/antisamy-ebay.xml
@@ -97,7 +97,7 @@ http://www.w3.org/TR/html401/struct/global.html
 		<regexp name="integer" value="(-|\+)?[0-9]+"/>
 		<regexp name="positiveInteger" value="(\+)?[0-9]+"/>
 		<regexp name="number" value="(-|\+)?([0-9]+(\.[0-9]+)?)"/>
-		<regexp name="angle" value="(-|\+)?([0-9]+(\.[0-9]+)?)(deg|grads|rad)"/>
+		<regexp name="angle" value="(-|\+)?([0-9]+(\.[0-9]+)?)(deg|grad|rad)"/>
 		<regexp name="time" value="([0-9]+(\.[0-9]+)?)(ms|s)"/>
 		<regexp name="frequency" value="([0-9]+(\.[0-9]+)?)(hz|khz)"/>
 		<regexp name="length" value="((-|\+)?0|(-|\+)?([0-9]+(\.[0-9]+)?)(em|ex|px|in|cm|mm|pt|pc))"/>

--- a/src/main/resources/antisamy-myspace.xml
+++ b/src/main/resources/antisamy-myspace.xml
@@ -99,7 +99,7 @@ http://www.w3.org/TR/html401/struct/global.html
 		<regexp name="integer" value="(-|\+)?[0-9]+"/>
 		<regexp name="positiveInteger" value="(\+)?[0-9]+"/>
 		<regexp name="number" value="(-|\+)?([0-9]+(\.[0-9]+)?)"/>
-		<regexp name="angle" value="(-|\+)?([0-9]+(\.[0-9]+)?)(deg|grads|rad)"/>
+		<regexp name="angle" value="(-|\+)?([0-9]+(\.[0-9]+)?)(deg|grad|rad)"/>
 		<regexp name="time" value="([0-9]+(\.[0-9]+)?)(ms|s)"/>
 		<regexp name="frequency" value="([0-9]+(\.[0-9]+)?)(hz|khz)"/>
 		<regexp name="length" value="((-|\+)?0|(-|\+)?([0-9]+(\.[0-9]+)?)(em|ex|px|in|cm|mm|pt|pc))"/>

--- a/src/main/resources/antisamy.xml
+++ b/src/main/resources/antisamy.xml
@@ -104,7 +104,7 @@ http://www.w3.org/TR/html401/struct/global.html
 		<regexp name="integer" value="(-|\+)?[0-9]+"/>
 		<regexp name="positiveInteger" value="(\+)?[0-9]+"/>
 		<regexp name="number" value="(-|\+)?([0-9]+(\.[0-9]+)?)"/>
-		<regexp name="angle" value="(-|\+)?([0-9]+(\.[0-9]+)?)(deg|grads|rad)"/>
+		<regexp name="angle" value="(-|\+)?([0-9]+(\.[0-9]+)?)(deg|grad|rad)"/>
 		<regexp name="time" value="([0-9]+(\.[0-9]+)?)(ms|s)"/>
 		<regexp name="frequency" value="([0-9]+(\.[0-9]+)?)(hz|khz)"/>	
 		<regexp name="length" value="((-|\+)?0|(-|\+)?([0-9]+(\.[0-9]+)?)(em|ex|px|in|cm|mm|pt|pc))"/>


### PR DESCRIPTION
The plural "grads" does not appear to be an acceptable unit
for a CSS `<angle>` type.

"Angle" in the policy files appears in the context of either
CSS Aural `azimuth` or `elevation` properties.

The W3 appendix on Aural stylesheets [1] lists `deg`, `grad` and `rad`
as valid units for `<angle>` types.

[1] https://www.w3.org/TR/CSS21/aural.html#value-def-angle