### PR TITLE
Older XML parsers such as Xerces do not support JAXP 1.5 properties

### DIFF
--- a/src/main/java/org/owasp/validator/html/scan/AntiSamySAXScanner.java
+++ b/src/main/java/org/owasp/validator/html/scan/AntiSamySAXScanner.java
@@ -57,9 +57,13 @@ public class AntiSamySAXScanner extends AbstractAntiSamyScanner {
     private static final TransformerFactory sTransformerFactory = TransformerFactory.newInstance();
 
     static {
-        // Disable external entities, etc.
-        sTransformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        sTransformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        try {
+            // Disable external entities, etc.
+            sTransformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            sTransformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        } catch (IllegalArgumentException e) {
+            // This exception will be thrown if the XML parser does not support JAXP 1.5 features
+        }
     }
 
     static class CachedItem {


### PR DESCRIPTION
Wrap the setting of JAXP properties in a try-catch block. These properties are in JAXP 1.5, and older parsers such as Xerces are not capable of handling them.