### PR TITLE
Add dependabot, bring all libraries up-to-date, update github actions to java version 2, and add ignores as needed to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,4 +14,7 @@ updates:
     ignore:
     - dependency-name: xml-apis:xml-apis
       versions:
-      - "> 2.0.0"
+      - "> 1.4.01"
+    - dependency-name: commons-io:commons-io
+      versions:
+      - "> 2.6"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: "maven"
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
+    labels:
+    - dependencies
+    ignore:
+    - dependency-name: xml-apis:xml-apis
+      versions:
+      - "> 2.0.0"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,8 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 1.8
+        distribution: zulu
     - name: Run unit tests
       run: mvn test

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up JDK 1.8
       uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        java-version: 8
         distribution: zulu
     - name: Run unit tests
       run: mvn test

--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.9.1</version>
+                <version>3.10.0</version>
             </plugin>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -380,7 +380,7 @@
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-pmd-plugin</artifactId>
-               <version>3.14.0</version>
+               <version>3.15.0</version>
                <configuration>
                    <targetJdk>1.7</targetJdk>
                    <sourceEncoding>utf-8</sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-javadoc-plugin</artifactId>
-                  <version>3.3.0</version>
+                  <version>3.3.1</version>
                   <configuration>
                      <!-- supports reproducibility of generated Javadocs -->
                      <notimestamp>true</notimestamp>

--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>2021-08-04T01:37:00Z</project.build.outputTimestamp>
         <gpg.skip>true</gpg.skip><!-- by default skip gpg -->
-        <version.spotbugs>4.3.0</version.spotbugs>
         <version.slf4j>1.7.32</version.slf4j>
         <version.spotbugs.maven>4.5.2.0</version.spotbugs.maven>
+        <version.spotbugs>4.5.2</version.spotbugs>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.14</version>
+            <version>4.4.15</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,7 @@
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>2.5.3</version>
                 <executions>
                   <execution>
                     <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
                     <dependency>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>extra-enforcer-rules</artifactId>
-                        <version>1.3</version>
+                        <version>1.5.1</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>2021-08-04T01:37:00Z</project.build.outputTimestamp>
         <gpg.skip>true</gpg.skip><!-- by default skip gpg -->
+        <version.io>2.6</version.io>
         <version.slf4j>1.7.32</version.slf4j>
         <version.spotbugs.maven>4.5.2.0</version.spotbugs.maven>
         <version.spotbugs>4.5.2</version.spotbugs>
@@ -106,12 +107,22 @@
             <artifactId>batik-css</artifactId>
             <version>1.14</version>
             <exclusions>
+                <!-- exclude this old version of commons-io as newer can be used -->
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
                 <!-- exclude this as batik-css has a dependency that uses an older commons-logging and we want to eliminate the convergence mismatch -->
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${version.io}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,10 @@
                     <artifactId>commons-codec</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
                    <groupId>org.apache.httpcomponents</groupId>
                    <artifactId>httpcore</artifactId>
                 </exclusion>
@@ -112,6 +116,11 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <version>${version.slf4j}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
             <version>${version.slf4j}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -411,7 +411,7 @@
                        <plugin>
                            <groupId>com.h3xstream.findsecbugs</groupId>
                            <artifactId>findsecbugs-plugin</artifactId>
-                           <version>1.10.1</version>
+                           <version>1.11.0</version>
                        </plugin>
                    </plugins>
                    <effort>Max</effort>

--- a/pom.xml
+++ b/pom.xml
@@ -173,12 +173,18 @@
             <artifactId>junit</artifactId>
             <version>4.13.2</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-          <version>2.2</version>
-          <scope>test</scope>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -410,7 +410,7 @@
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-project-info-reports-plugin</artifactId>
-               <version>3.1.1</version>
+               <version>3.1.2</version>
                <reportSets>
                  <reportSet>
                    <reports>

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M3</version>
+                <version>3.0.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>2021-08-04T01:37:00Z</project.build.outputTimestamp>
         <gpg.skip>true</gpg.skip><!-- by default skip gpg -->
-        <version.spotbugs.maven>4.2.3</version.spotbugs.maven>
         <version.spotbugs>4.3.0</version.spotbugs>
         <version.slf4j>1.7.32</version.slf4j>
+        <version.spotbugs.maven>4.5.2.0</version.spotbugs.maven>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>2021-08-04T01:37:00Z</project.build.outputTimestamp>
         <gpg.skip>true</gpg.skip><!-- by default skip gpg -->
-        <version.slf4j>1.7.31</version.slf4j>
         <version.spotbugs.maven>4.2.3</version.spotbugs.maven>
         <version.spotbugs>4.3.0</version.spotbugs>
+        <version.slf4j>1.7.32</version.slf4j>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -382,6 +382,19 @@
                   </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-pmd-plugin</artifactId>
+               <version>3.15.0</version>
+               <dependencies>
+                   <!-- Necessary on pmd 3.15.0 only due to leak of old asm, remove this after next pmd plugin release -->
+                   <dependency>
+                       <groupId>org.ow2.asm</groupId>
+                       <artifactId>asm</artifactId>
+                       <version>9.2</version>
+                   </dependency>
+               </dependencies>
+            </plugin>
         </plugins>
     </build>
     <reporting>
@@ -447,4 +460,3 @@
         </plugins>
     </reporting>
 </project>
-


### PR DESCRIPTION
This brings everything up to date and still java 7 compliant.