### PR TITLE
Add support for noopener and noreferrer in anchors

### DIFF
--- a/src/main/java/org/owasp/validator/html/InternalPolicy.java
+++ b/src/main/java/org/owasp/validator/html/InternalPolicy.java
@@ -50,6 +50,11 @@ public class InternalPolicy extends Policy {
         this.styleTag = getTagByLowercaseName("style");
         this.embedStyleSheets = isTrue(Policy.EMBED_STYLESHEETS);
         this.allowDynamicAttributes = isTrue(Policy.ALLOW_DYNAMIC_ATTRIBUTES);
+
+        if (!isNoopenerAndNoreferrerAnchors) {
+            logger.warn("The directive \"" + Policy.ANCHORS_NOOPENER_NOREFERRER +
+                    "\" is not enabled by default. It is recommended to enable it to prevent reverse tabnabbing attacks.");
+        }
     }
 
     protected InternalPolicy(Policy old, Map<String, String> directives, Map<String, Tag> tagRules) {
@@ -71,6 +76,11 @@ public class InternalPolicy extends Policy {
         this.styleTag = getTagByLowercaseName("style");
         this.embedStyleSheets = isTrue(Policy.EMBED_STYLESHEETS);
         this.allowDynamicAttributes = isTrue(Policy.ALLOW_DYNAMIC_ATTRIBUTES);
+        
+        if (!isNoopenerAndNoreferrerAnchors) {
+            logger.warn("The directive \"" + Policy.ANCHORS_NOOPENER_NOREFERRER +
+                    "\" is not enabled by default. It is recommended to enable it to prevent reverse tabnabbing attacks.");
+        }
     }
 
     public Tag getEmbedTag() {

--- a/src/main/java/org/owasp/validator/html/InternalPolicy.java
+++ b/src/main/java/org/owasp/validator/html/InternalPolicy.java
@@ -14,6 +14,7 @@ import java.util.Map;
 public class InternalPolicy extends Policy {
     private final int maxInputSize;
     private final boolean isNofollowAnchors;
+    private final boolean isNoopenerAndNoreferrerAnchors;
     private final boolean isValidateParamAsEmbed;
     private final boolean formatOutput;
     private final boolean preserveSpace;
@@ -34,6 +35,7 @@ public class InternalPolicy extends Policy {
         super(parseContext);
         this.maxInputSize = determineMaxInputSize();
         this.isNofollowAnchors = isTrue(Policy.ANCHORS_NOFOLLOW);
+        this.isNoopenerAndNoreferrerAnchors = isTrue(Policy.ANCHORS_NOOPENER_NOREFERRER);
         this.isValidateParamAsEmbed = isTrue(Policy.VALIDATE_PARAM_AS_EMBED);
         this.formatOutput = isTrue(Policy.FORMAT_OUTPUT);
         this.preserveSpace = isTrue(Policy.PRESERVE_SPACE);
@@ -54,6 +56,7 @@ public class InternalPolicy extends Policy {
         super(old, directives, tagRules);
         this.maxInputSize = determineMaxInputSize();
         this.isNofollowAnchors = isTrue(Policy.ANCHORS_NOFOLLOW);
+        this.isNoopenerAndNoreferrerAnchors = isTrue(Policy.ANCHORS_NOOPENER_NOREFERRER);
         this.isValidateParamAsEmbed = isTrue(Policy.VALIDATE_PARAM_AS_EMBED);
         this.formatOutput = isTrue(Policy.FORMAT_OUTPUT);
         this.preserveSpace = isTrue(Policy.PRESERVE_SPACE);
@@ -96,6 +99,10 @@ public class InternalPolicy extends Policy {
 
     public boolean isNofollowAnchors() {
         return isNofollowAnchors;
+    }
+
+    public boolean isNoopenerAndNoreferrerAnchors() {
+        return isNoopenerAndNoreferrerAnchors;
     }
 
     public boolean isValidateParamAsEmbed() {

--- a/src/main/java/org/owasp/validator/html/InternalPolicy.java
+++ b/src/main/java/org/owasp/validator/html/InternalPolicy.java
@@ -76,7 +76,7 @@ public class InternalPolicy extends Policy {
         this.styleTag = getTagByLowercaseName("style");
         this.embedStyleSheets = isTrue(Policy.EMBED_STYLESHEETS);
         this.allowDynamicAttributes = isTrue(Policy.ALLOW_DYNAMIC_ATTRIBUTES);
-        
+
         if (!isNoopenerAndNoreferrerAnchors) {
             logger.warn("The directive \"" + Policy.ANCHORS_NOOPENER_NOREFERRER +
                     "\" is not enabled by default. It is recommended to enable it to prevent reverse tabnabbing attacks.");

--- a/src/main/java/org/owasp/validator/html/Policy.java
+++ b/src/main/java/org/owasp/validator/html/Policy.java
@@ -138,6 +138,7 @@ public class Policy {
     public static final String EMBED_STYLESHEETS = "embedStyleSheets";
     public static final String CONNECTION_TIMEOUT = "connectionTimeout";
     public static final String ANCHORS_NOFOLLOW = "nofollowAnchors";
+    public static final String ANCHORS_NOOPENER_NOREFERRER = "noopenerAndNoreferrerAnchors";
     public static final String VALIDATE_PARAM_AS_EMBED = "validateParamAsEmbed";
     public static final String PRESERVE_SPACE = "preserveSpace";
     public static final String PRESERVE_COMMENTS = "preserveComments";

--- a/src/main/java/org/owasp/validator/html/Policy.java
+++ b/src/main/java/org/owasp/validator/html/Policy.java
@@ -120,7 +120,7 @@ import static org.owasp.validator.html.util.XMLUtil.getAttributeValue;
 
 public class Policy {
 
-    private static final Logger logger = LoggerFactory.getLogger(Policy.class);
+    protected static final Logger logger = LoggerFactory.getLogger(Policy.class);
 
     public static final Pattern ANYTHING_REGEXP = Pattern.compile(".*", Pattern.DOTALL);
 
@@ -339,6 +339,8 @@ public class Policy {
         this.directives = Collections.unmodifiableMap(parseContext.directives);
         this.globalAttributes = Collections.unmodifiableMap(parseContext.globalAttributes);
         this.dynamicAttributes = Collections.unmodifiableMap(parseContext.dynamicAttributes);
+
+
     }
 
     protected Policy(Policy old, Map<String, String> directives, Map<String, Tag> tagRules) {

--- a/src/main/java/org/owasp/validator/html/Policy.java
+++ b/src/main/java/org/owasp/validator/html/Policy.java
@@ -339,8 +339,6 @@ public class Policy {
         this.directives = Collections.unmodifiableMap(parseContext.directives);
         this.globalAttributes = Collections.unmodifiableMap(parseContext.globalAttributes);
         this.dynamicAttributes = Collections.unmodifiableMap(parseContext.dynamicAttributes);
-
-
     }
 
     protected Policy(Policy old, Map<String, String> directives, Map<String, Tag> tagRules) {

--- a/src/main/java/org/owasp/validator/html/model/Attribute.java
+++ b/src/main/java/org/owasp/validator/html/model/Attribute.java
@@ -161,8 +161,7 @@ public class Attribute  {
         if (currentRelValue == null || currentRelValue.isEmpty()) {
             if (addNofollow) newRelValue = "nofollow";
             if (addNoopenerAndNoreferrer) newRelValue += " noopener noreferrer";
-        }
-        else {
+        } else {
             ArrayList<String> relTokens = new ArrayList<>();
             newRelValue = currentRelValue;
             for (String value: currentRelValue.split(" ")) {

--- a/src/main/java/org/owasp/validator/html/model/Attribute.java
+++ b/src/main/java/org/owasp/validator/html/model/Attribute.java
@@ -143,6 +143,35 @@ public class Attribute  {
             }
         }
         return regExp.toString();
+    }
 
+    public static String mergeRelValuesInAnchor(boolean addNofollow, boolean addNoopenerAndNoreferrer, String currentRelValue) {
+        String newRelValue = "";
+        if (currentRelValue == null || currentRelValue.isEmpty()) {
+            if (addNofollow) newRelValue = "nofollow";
+            if (addNoopenerAndNoreferrer) newRelValue += " noopener noreferrer";
+        }
+        else {
+            ArrayList<String> relTokens = new ArrayList<>();
+            newRelValue = currentRelValue;
+            for (String value: currentRelValue.split(" ")) {
+                relTokens.add(value.toLowerCase());
+            }
+
+            if (addNofollow && !relTokens.contains("nofollow")) {
+                newRelValue += " nofollow";
+            }
+
+            if (addNoopenerAndNoreferrer) {
+                if (!relTokens.contains("noopener")){
+                    newRelValue += " noopener";
+                }
+                if (!relTokens.contains("noreferrer")){
+                    newRelValue += " noreferrer";
+                }
+            }
+        }
+
+        return newRelValue.trim();
     }
 }

--- a/src/main/java/org/owasp/validator/html/model/Attribute.java
+++ b/src/main/java/org/owasp/validator/html/model/Attribute.java
@@ -145,6 +145,17 @@ public class Attribute  {
         return regExp.toString();
     }
 
+    /**
+     * This method takes the current <code>rel</code> attribute values and, depending on which ones to add,
+     * appends the corresponding values if they are not already present. It is meant to be used with anchor tags.
+     *
+     * @param addNofollow Specifies if <code>"nofollow"</code> value should be added in case it is not present.
+     * @param addNoopenerAndNoreferrer Specifies if <code>"noopener noreferrer"</code> value should be added in case
+     *                                 it is not present.
+     * @param currentRelValue Current <code>rel</code> attribute value, it will be merged with the values specified
+     *                        from the previous parameters.
+     * @return The new <code>rel</code> attribute value to replace in an anchor tag.
+     */
     public static String mergeRelValuesInAnchor(boolean addNofollow, boolean addNoopenerAndNoreferrer, String currentRelValue) {
         String newRelValue = "";
         if (currentRelValue == null || currentRelValue.isEmpty()) {

--- a/src/main/java/org/owasp/validator/html/scan/AbstractAntiSamyScanner.java
+++ b/src/main/java/org/owasp/validator/html/scan/AbstractAntiSamyScanner.java
@@ -49,6 +49,7 @@ public abstract class AbstractAntiSamyScanner {
     protected final Locale locale = Locale.getDefault();
 
     protected boolean isNofollowAnchors = false;
+    protected boolean isNoopenerAndNoreferrerAnchors = false;
     protected boolean isValidateParamAsEmbed = false;
 
     public abstract CleanResults scan(String html) throws ScanException;

--- a/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
+++ b/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
@@ -35,8 +35,6 @@ import org.owasp.validator.html.model.Attribute;
 import org.owasp.validator.html.model.Tag;
 import org.owasp.validator.html.util.ErrorMessageUtil;
 import org.owasp.validator.html.util.HTMLEntityEncoder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.w3c.dom.Comment;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
@@ -79,8 +77,6 @@ public class AntiSamyDOMScanner extends AbstractAntiSamyScanner {
     private static final Pattern conditionalDirectives = Pattern.compile("<?!?\\[\\s*(?:end)?if[^]]*\\]>?");
 
     private static final Queue<CachedItem> cachedItems = new ConcurrentLinkedQueue<CachedItem>();
-
-    private static final Logger logger = LoggerFactory.getLogger(AntiSamyDOMScanner.class);
 
     static class CachedItem {
         private final DOMFragmentParser parser;
@@ -381,10 +377,6 @@ public class AntiSamyDOMScanner extends AbstractAntiSamyScanner {
                 if (targetAttribute != null && targetAttribute.getNodeValue().equalsIgnoreCase("_blank")) {
                     addNoopenerAndNoreferrer = true;
                 }
-            }
-            else {
-                logger.warn("The directive \"" + Policy.ANCHORS_NOOPENER_NOREFERRER +
-                        "\" is not enabled by default. It is recommended to enable it to prevent reverse tabnabbing attacks.");
             }
 
             Node relAttribute = ele.getAttributes().getNamedItem("rel");

--- a/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
+++ b/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
@@ -35,6 +35,8 @@ import org.owasp.validator.html.model.Attribute;
 import org.owasp.validator.html.model.Tag;
 import org.owasp.validator.html.util.ErrorMessageUtil;
 import org.owasp.validator.html.util.HTMLEntityEncoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Comment;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
@@ -68,7 +70,6 @@ import java.util.regex.Pattern;
  * @author Arshan Dabirsiaghi
  */
 public class AntiSamyDOMScanner extends AbstractAntiSamyScanner {
-
     private Document document = new DocumentImpl();
     private DocumentFragment dom = document.createDocumentFragment();
     private CleanResults results = null;
@@ -78,6 +79,8 @@ public class AntiSamyDOMScanner extends AbstractAntiSamyScanner {
     private static final Pattern conditionalDirectives = Pattern.compile("<?!?\\[\\s*(?:end)?if[^]]*\\]>?");
 
     private static final Queue<CachedItem> cachedItems = new ConcurrentLinkedQueue<CachedItem>();
+
+    private static final Logger logger = LoggerFactory.getLogger(AntiSamyDOMScanner.class);
 
     static class CachedItem {
         private final DOMFragmentParser parser;
@@ -378,6 +381,10 @@ public class AntiSamyDOMScanner extends AbstractAntiSamyScanner {
                 if (targetAttribute != null && targetAttribute.getNodeValue().equalsIgnoreCase("_blank")) {
                     addNoopenerAndNoreferrer = true;
                 }
+            }
+            else {
+                logger.warn("The directive \"" + Policy.ANCHORS_NOOPENER_NOREFERRER +
+                        "\" is not enabled by default. It is recommended to enable it to prevent reverse tabnabbing attacks.");
             }
 
             Node relAttribute = ele.getAttributes().getNamedItem("rel");

--- a/src/main/java/org/owasp/validator/html/scan/MagicSAXFilter.java
+++ b/src/main/java/org/owasp/validator/html/scan/MagicSAXFilter.java
@@ -85,11 +85,11 @@ public class MagicSAXFilter extends DefaultFilter implements XMLDocumentFilter {
     public void reset(InternalPolicy instance){
         this.policy = instance;
         isNofollowAnchors = policy.isNofollowAnchors();
-		isNoopenerAndNoreferrerAnchors = policy.isNoopenerAndNoreferrerAnchors();
+        isNoopenerAndNoreferrerAnchors = policy.isNoopenerAndNoreferrerAnchors();
         isValidateParamAsEmbed = policy.isValidateParamAsEmbed();
         preserveComments = policy.isPreserveComments();
         maxInputSize = policy.getMaxInputSize();
-		shouldParseImportedStyles = policy.isEmbedStyleSheets();
+        shouldParseImportedStyles = policy.isEmbedStyleSheets();
         operations.clear();
         errorMessages.clear();
         cssContent = null;

--- a/src/main/java/org/owasp/validator/html/scan/MagicSAXFilter.java
+++ b/src/main/java/org/owasp/validator/html/scan/MagicSAXFilter.java
@@ -46,6 +46,8 @@ import org.owasp.validator.html.model.Attribute;
 import org.owasp.validator.html.model.Tag;
 import org.owasp.validator.html.util.ErrorMessageUtil;
 import org.owasp.validator.html.util.HTMLEntityEncoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of an HTML-filter that adheres to an AntiSamy policy. This
@@ -73,6 +75,8 @@ public class MagicSAXFilter extends DefaultFilter implements XMLDocumentFilter {
     private boolean preserveComments;
     private int maxInputSize;
     private boolean shouldParseImportedStyles;
+
+	private static final Logger logger = LoggerFactory.getLogger(MagicSAXFilter.class);
 
     public MagicSAXFilter(ResourceBundle messages) {
 		this.messages = messages;
@@ -374,6 +378,10 @@ public class MagicSAXFilter extends DefaultFilter implements XMLDocumentFilter {
 							if (targetValue != null && targetValue.equalsIgnoreCase("_blank")) {
 								addNoopenerAndNoreferrer = true;
 							}
+						}
+						else {
+							logger.warn("The directive \"" + Policy.ANCHORS_NOOPENER_NOREFERRER +
+									"\" is not enabled by default. It is recommended to enable it to prevent reverse tabnabbing attacks.");
 						}
 
 						String currentRelValue = attributes.getValue("rel");

--- a/src/main/java/org/owasp/validator/html/scan/MagicSAXFilter.java
+++ b/src/main/java/org/owasp/validator/html/scan/MagicSAXFilter.java
@@ -46,8 +46,6 @@ import org.owasp.validator.html.model.Attribute;
 import org.owasp.validator.html.model.Tag;
 import org.owasp.validator.html.util.ErrorMessageUtil;
 import org.owasp.validator.html.util.HTMLEntityEncoder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of an HTML-filter that adheres to an AntiSamy policy. This
@@ -75,8 +73,6 @@ public class MagicSAXFilter extends DefaultFilter implements XMLDocumentFilter {
     private boolean preserveComments;
     private int maxInputSize;
     private boolean shouldParseImportedStyles;
-
-	private static final Logger logger = LoggerFactory.getLogger(MagicSAXFilter.class);
 
     public MagicSAXFilter(ResourceBundle messages) {
 		this.messages = messages;
@@ -378,10 +374,6 @@ public class MagicSAXFilter extends DefaultFilter implements XMLDocumentFilter {
 							if (targetValue != null && targetValue.equalsIgnoreCase("_blank")) {
 								addNoopenerAndNoreferrer = true;
 							}
-						}
-						else {
-							logger.warn("The directive \"" + Policy.ANCHORS_NOOPENER_NOREFERRER +
-									"\" is not enabled by default. It is recommended to enable it to prevent reverse tabnabbing attacks.");
 						}
 
 						String currentRelValue = attributes.getValue("rel");

--- a/src/main/java/org/owasp/validator/html/scan/MagicSAXFilter.java
+++ b/src/main/java/org/owasp/validator/html/scan/MagicSAXFilter.java
@@ -376,7 +376,15 @@ public class MagicSAXFilter extends DefaultFilter implements XMLDocumentFilter {
 							}
 						}
 
-						String relValue = Attribute.mergeRelValuesInAnchor(addNofollow, addNoopenerAndNoreferrer, attributes.getValue("rel"));
+						String currentRelValue = attributes.getValue("rel");
+						if (currentRelValue != null) {
+							Attribute attribute = tag.getAttributeByName("rel");
+							if (attribute != null &&
+									!(attribute.containsAllowedValue(currentRelValue) || attribute.matchesAllowedExpression(currentRelValue))) {
+								currentRelValue = "";
+							}
+						}
+						String relValue = Attribute.mergeRelValuesInAnchor(addNofollow, addNoopenerAndNoreferrer, currentRelValue);
 						if (!relValue.isEmpty()){
 							validattributes.addAttribute(makeSimpleQname("rel"), "CDATA", relValue);
 						}

--- a/src/main/java/org/owasp/validator/html/scan/MagicSAXFilter.java
+++ b/src/main/java/org/owasp/validator/html/scan/MagicSAXFilter.java
@@ -66,6 +66,7 @@ public class MagicSAXFilter extends DefaultFilter implements XMLDocumentFilter {
 	private ResourceBundle messages;
 
 	private boolean isNofollowAnchors;
+	private boolean isNoopenerAndNoreferrerAnchors;
 	private boolean isValidateParamAsEmbed;
 	private boolean inCdata = false;
     // From policy
@@ -80,6 +81,7 @@ public class MagicSAXFilter extends DefaultFilter implements XMLDocumentFilter {
     public void reset(InternalPolicy instance){
         this.policy = instance;
         isNofollowAnchors = policy.isNofollowAnchors();
+		isNoopenerAndNoreferrerAnchors = policy.isNoopenerAndNoreferrerAnchors();
         isValidateParamAsEmbed = policy.isValidateParamAsEmbed();
         preserveComments = policy.isPreserveComments();
         maxInputSize = policy.getMaxInputSize();
@@ -363,8 +365,21 @@ public class MagicSAXFilter extends DefaultFilter implements XMLDocumentFilter {
 					this.operations.push(Ops.FILTER);
 				} else {
 
-					if (isNofollowAnchors && "a".equals(element.localpart)) {
-						validattributes.addAttribute(makeSimpleQname("rel"), "CDATA", "nofollow");
+					if ("a".equals(element.localpart)) {
+						boolean addNofollow = isNofollowAnchors;
+						boolean addNoopenerAndNoreferrer = false;
+
+						if (isNoopenerAndNoreferrerAnchors) {
+							String targetValue = attributes.getValue("target");
+							if (targetValue != null && targetValue.equalsIgnoreCase("_blank")) {
+								addNoopenerAndNoreferrer = true;
+							}
+						}
+
+						String relValue = Attribute.mergeRelValuesInAnchor(addNofollow, addNoopenerAndNoreferrer, attributes.getValue("rel"));
+						if (!relValue.isEmpty()){
+							validattributes.addAttribute(makeSimpleQname("rel"), "CDATA", relValue);
+						}
 					}
 
 					if (masqueradingParam) {

--- a/src/main/resources/antisamy.xml
+++ b/src/main/resources/antisamy.xml
@@ -796,9 +796,9 @@ http://www.w3.org/TR/html401/struct/global.html
 				</regexp-list>
 			</attribute>
 			<attribute name="rel">
-				<literal-list>
-					<literal value="nofollow"/>
-				</literal-list>
+				<regexp-list>
+					<regexp value="(\s*(nofollow|noopener|noreferrer)(\s(nofollow|noopener|noreferrer))*\s*)?"/>
+				</regexp-list>
 			</attribute>
 			<attribute name="name"/>
 			

--- a/src/main/resources/antisamy.xml
+++ b/src/main/resources/antisamy.xml
@@ -18,6 +18,7 @@ http://www.w3.org/TR/html401/struct/global.html
 		<directive name="formatOutput" value="true"/>
 		<directive name="nofollowAnchors" value="true" />
 		<directive name="validateParamAsEmbed" value="true" />
+		<directive name="noopenerAndNoreferrerAnchors" value="false" />
 		
 		<!--
 		remember, this won't work for relative URIs - AntiSamy doesn't

--- a/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
@@ -50,8 +50,11 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URL;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.ExecutionException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.hamcrest.CoreMatchers.both;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -49,7 +50,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URL;
-import java.util.Collections;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1599,6 +1600,47 @@ static final String test33 = "<html>\n"
         assertThat(cleanHtmlSAX, not(containsString(".grid_1")));
         assertThat(cleanHtmlDOM, not(containsString(".janrain-provider150-sprit")));
         assertThat(cleanHtmlSAX, not(containsString(".janrain-provider150-sprit")));
+    }
+
+    @Test
+    public void testNoopenerAndNoreferrer() throws ScanException, PolicyException {
+        Map<String, Attribute> map = new HashMap<>();
+        map.put("target", new Attribute("a", Collections.<Pattern>emptyList(), Arrays.asList( "_blank", "_self" ), "",""));
+        map.put("rel", new Attribute("a", Collections.<Pattern>emptyList(), Arrays.asList( "nofollow", "noopener", "noreferrer"), "",""));
+        Tag tag = new Tag("a", map, Policy.ACTION_VALIDATE);
+        Policy basePolicy = policy.mutateTag(tag);
+        Policy revised = basePolicy.cloneWithDirective(Policy.ANCHORS_NOFOLLOW,"true").cloneWithDirective(Policy.ANCHORS_NOOPENER_NOREFERRER,"true");
+        // No target="_blank", so only nofollow can be added.
+        assertThat(as.scan("<a>Link text</a>", revised, AntiSamy.DOM).getCleanHTML(), both(containsString("nofollow")).and(not(containsString("noopener noreferrer"))));
+        assertThat(as.scan("<a>Link text</a>", revised, AntiSamy.SAX).getCleanHTML(), both(containsString("nofollow")).and(not(containsString("noopener noreferrer"))));
+        // target="_blank", can have both.
+        assertThat(as.scan("<a target=\"_blank\">Link text</a>", revised, AntiSamy.DOM).getCleanHTML(), containsString("nofollow noopener noreferrer"));
+        assertThat(as.scan("<a target=\"_blank\">Link text</a>", revised, AntiSamy.SAX).getCleanHTML(), containsString("nofollow noopener noreferrer"));
+
+        Policy revised2 = basePolicy.cloneWithDirective(Policy.ANCHORS_NOFOLLOW,"false").cloneWithDirective(Policy.ANCHORS_NOOPENER_NOREFERRER,"true");
+        // No target="_blank", no rel added.
+        assertThat(as.scan("<a>Link text</a>", revised2, AntiSamy.DOM).getCleanHTML(), not(containsString("rel=")));
+        assertThat(as.scan("<a>Link text</a>", revised2, AntiSamy.SAX).getCleanHTML(), not(containsString("rel=")));
+        // target="_blank", everything present.
+        assertThat(as.scan("<a target='_blank' rel='nofollow'>Link text</a>", revised2, AntiSamy.DOM).getCleanHTML(), containsString("nofollow noopener noreferrer"));
+        assertThat(as.scan("<a target='_blank' rel='nofollow'>Link text</a>", revised2, AntiSamy.SAX).getCleanHTML(), containsString("nofollow noopener noreferrer"));
+        // target="_self", no rel added.
+        assertThat(as.scan("<a target='_self'>Link text</a>", revised2, AntiSamy.DOM).getCleanHTML(), not(containsString("rel=")));
+        assertThat(as.scan("<a target='_self'>Link text</a>", revised2, AntiSamy.SAX).getCleanHTML(), not(containsString("rel=")));
+        // target="_self", only nofollow present.
+        assertThat(as.scan("<a target='_self' rel='nofollow'>Link text</a>", revised2, AntiSamy.DOM).getCleanHTML(), both(containsString("nofollow")).and(not(containsString("noopener noreferrer"))));
+        assertThat(as.scan("<a target='_self' rel='nofollow'>Link text</a>", revised2, AntiSamy.SAX).getCleanHTML(), both(containsString("nofollow")).and(not(containsString("noopener noreferrer"))));
+        // noopener is not repeated
+        assertThat(as.scan("<a target='_blank' rel='noopener'>Link text</a>", revised2, AntiSamy.DOM).getCleanHTML().split("noopener").length, is(2));
+        assertThat(as.scan("<a target='_blank' rel='noopener'>Link text</a>", revised2, AntiSamy.SAX).getCleanHTML().split("noopener").length, is(2));
+
+        Policy revised3 = basePolicy.cloneWithDirective(Policy.ANCHORS_NOFOLLOW,"false").cloneWithDirective(Policy.ANCHORS_NOOPENER_NOREFERRER,"false");
+        // No rel added
+        assertThat(as.scan("<a>Link text</a>", revised3, AntiSamy.DOM).getCleanHTML(), not(containsString("rel=")));
+        assertThat(as.scan("<a>Link text</a>", revised3, AntiSamy.SAX).getCleanHTML(), not(containsString("rel=")));
+        // noopener is not repeated
+        assertThat(as.scan("<a target='_blank' rel='noopener'>Link text</a>", revised3, AntiSamy.DOM).getCleanHTML().split("noopener").length, is(2));
+        assertThat(as.scan("<a target='_blank' rel='noopener'>Link text</a>", revised3, AntiSamy.SAX).getCleanHTML().split("noopener").length, is(2));
     }
 }
 


### PR DESCRIPTION
Fixes #89. This adds a directive (false by default) to allow adding `noopener` and `noreferrer` (at the same time) on anchor tags, just like `nofollow` but work separately.

With DOM, attributes are processed and AntiSamy then adds or not the corresponding values to `rel` attribute.
With SAX, AntiSamy adds or not the corresponding values to `rel` attribute depending on directive values and in that moment checks valid values for the `rel` attribute. It's more like a backward compatibility behavior shown in a `nofollow` test case.

Default policy has the new directive and allows the presence of `nofollow`, `noopener` and `noreferrer` only (only `nofollow` before) with a regular expression.