### PR TITLE
Support for leading dash on CSS property names

### DIFF
--- a/src/main/java/org/owasp/validator/css/CssParser.java
+++ b/src/main/java/org/owasp/validator/css/CssParser.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2007-2022, Arshan Dabirsiaghi, Sebastián Passaro
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice,
+ * 	 this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of OWASP nor the names of its contributors may be used to
+ *   endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.owasp.validator.css;
+
+import org.apache.batik.css.parser.LexicalUnits;
+import org.w3c.css.sac.CSSException;
+import org.w3c.css.sac.CSSParseException;
+import org.w3c.css.sac.LexicalUnit;
+
+public class CssParser extends org.apache.batik.css.parser.Parser {
+
+    /**
+     * This implementation is a workaround to solve leading dash errors on property names.
+     * @see <code>https://issues.apache.org/jira/browse/BATIK-1112</code>
+     * @param inSheet
+     * @throws CSSException
+     */
+    protected void parseStyleDeclaration(final boolean inSheet) throws CSSException {
+        boolean leadingDash = false;
+        for (;;) {
+            switch (current) {
+                case LexicalUnits.EOF:
+                    if (inSheet) {
+                        throw createCSSParseException("eof");
+                    }
+                    return;
+                case LexicalUnits.RIGHT_CURLY_BRACE:
+                    if (!inSheet) {
+                        throw createCSSParseException("eof.expected");
+                    }
+                    nextIgnoreSpaces();
+                    return;
+                case LexicalUnits.SEMI_COLON:
+                    nextIgnoreSpaces();
+                    continue;
+                case LexicalUnits.MINUS:
+                    leadingDash = true;
+                    next();
+                    break;
+                default:
+                    throw createCSSParseException("identifier");
+                case LexicalUnits.IDENTIFIER:
+            }
+
+            final String name = (leadingDash ? "-" : "") + scanner.getStringValue();
+            leadingDash = false;
+
+            if (nextIgnoreSpaces() != LexicalUnits.COLON) {
+                throw createCSSParseException("colon");
+            }
+            nextIgnoreSpaces();
+
+            LexicalUnit exp = null;
+
+            try {
+                exp = parseExpression(false);
+            } catch (final CSSParseException e) {
+                reportError(e);
+            }
+
+            if (exp != null) {
+                boolean important = false;
+                if (current == LexicalUnits.IMPORTANT_SYMBOL) {
+                    important = true;
+                    nextIgnoreSpaces();
+                }
+                documentHandler.property(name, exp, important);
+            }
+        }
+    }
+}

--- a/src/main/java/org/owasp/validator/css/CssParser.java
+++ b/src/main/java/org/owasp/validator/css/CssParser.java
@@ -38,8 +38,8 @@ public class CssParser extends org.apache.batik.css.parser.Parser {
     /**
      * This implementation is a workaround to solve leading dash errors on property names.
      * @see <code>https://issues.apache.org/jira/browse/BATIK-1112</code>
-     * @param inSheet
-     * @throws CSSException
+     * @param inSheet Specifies if the style to parse is inside a sheet or the sheet itself.
+     * @throws CSSException Thrown if there are parsing errors in CSS
      */
     protected void parseStyleDeclaration(final boolean inSheet) throws CSSException {
         boolean leadingDash = false;

--- a/src/main/java/org/owasp/validator/css/CssScanner.java
+++ b/src/main/java/org/owasp/validator/css/CssScanner.java
@@ -77,7 +77,7 @@ public class CssScanner {
     /**
      * The parser to be used in any scanning
      */
-    private final Parser parser = new Parser();
+    private final Parser parser = new CssParser();
 
     /**
      * The policy file to be used in any scanning

--- a/src/main/java/org/owasp/validator/html/InternalPolicy.java
+++ b/src/main/java/org/owasp/validator/html/InternalPolicy.java
@@ -1,5 +1,6 @@
 package org.owasp.validator.html;
 
+import org.owasp.validator.html.model.Property;
 import org.owasp.validator.html.model.Tag;
 
 import java.util.Map;
@@ -57,8 +58,8 @@ public class InternalPolicy extends Policy {
         }
     }
 
-    protected InternalPolicy(Policy old, Map<String, String> directives, Map<String, Tag> tagRules) {
-        super(old, directives, tagRules);
+    protected InternalPolicy(Policy old, Map<String, String> directives, Map<String, Tag> tagRules, Map<String, Property> cssRules) {
+        super(old, directives, tagRules, cssRules);
         this.maxInputSize = determineMaxInputSize();
         this.isNofollowAnchors = isTrue(Policy.ANCHORS_NOFOLLOW);
         this.isNoopenerAndNoreferrerAnchors = isTrue(Policy.ANCHORS_NOOPENER_NOREFERRER);

--- a/src/main/java/org/owasp/validator/html/Policy.java
+++ b/src/main/java/org/owasp/validator/html/Policy.java
@@ -156,7 +156,7 @@ public class Policy {
 
     private final Map<String, AntiSamyPattern> commonRegularExpressions;
     protected final Map<String, Tag> tagRules;
-    private final Map<String, Property> cssRules;
+    protected final Map<String, Property> cssRules;
     protected final Map<String, String> directives;
     private final Map<String, Attribute> globalAttributes;
     private final Map<String, Attribute> dynamicAttributes;
@@ -341,12 +341,12 @@ public class Policy {
         this.dynamicAttributes = Collections.unmodifiableMap(parseContext.dynamicAttributes);
     }
 
-    protected Policy(Policy old, Map<String, String> directives, Map<String, Tag> tagRules) {
+    protected Policy(Policy old, Map<String, String> directives, Map<String, Tag> tagRules, Map<String, Property> cssRules) {
         this.allowedEmptyTagsMatcher = old.allowedEmptyTagsMatcher;
         this.requiresClosingTagsMatcher = old.requiresClosingTagsMatcher;
         this.commonRegularExpressions = old.commonRegularExpressions;
         this.tagRules = tagRules;
-        this.cssRules = old.cssRules;
+        this.cssRules = cssRules;
         this.directives = directives;
         this.globalAttributes = old.globalAttributes;
         this.dynamicAttributes = old.dynamicAttributes;
@@ -634,7 +634,7 @@ public class Policy {
     public Policy cloneWithDirective(String name, String value) {
         Map<String, String> directives = new HashMap<String, String>(this.directives);
         directives.put(name, value);
-        return new InternalPolicy(this, Collections.unmodifiableMap(directives), tagRules);
+        return new InternalPolicy(this, Collections.unmodifiableMap(directives), tagRules, cssRules);
     }
 
     /**

--- a/src/test/java/org/owasp/validator/html/test/TestPolicy.java
+++ b/src/test/java/org/owasp/validator/html/test/TestPolicy.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import org.owasp.validator.html.InternalPolicy;
 import org.owasp.validator.html.Policy;
 import org.owasp.validator.html.PolicyException;
+import org.owasp.validator.html.model.Property;
 import org.owasp.validator.html.model.Tag;
 
 /**
@@ -46,8 +47,8 @@ public class TestPolicy extends InternalPolicy {
         super(parseContext);
     }
 
-    protected TestPolicy(Policy old, Map<String, String> directives, Map<String, Tag> tagRules) {
-        super(old, directives, tagRules);
+    protected TestPolicy(Policy old, Map<String, String> directives, Map<String, Tag> tagRules, Map<String, Property> cssRules) {
+        super(old, directives, tagRules, cssRules);
     }
 
     public static TestPolicy getInstance() throws PolicyException {
@@ -75,20 +76,24 @@ public class TestPolicy extends InternalPolicy {
     public TestPolicy cloneWithDirective(String name, String value) {
         Map<String, String> directives = new HashMap<String, String>(this.directives);
         directives.put(name, value);
-        return new TestPolicy(this, Collections.unmodifiableMap(directives), tagRules);
+        return new TestPolicy(this, Collections.unmodifiableMap(directives), tagRules, cssRules);
     }
 
     public TestPolicy addTagRule(Tag tag) {
         Map<String, Tag> newTagRules = new HashMap<String, Tag>(tagRules);
         newTagRules.put(tag.getName().toLowerCase(), tag);
-        return new TestPolicy(this, this.directives, newTagRules);
-
+        return new TestPolicy(this, this.directives, newTagRules, cssRules);
     }
 
     public TestPolicy mutateTag(Tag tag) {
-        Map<String, Tag> newRUles = new HashMap<String, Tag>(this.tagRules);
-        newRUles.put( tag.getName().toLowerCase(), tag);
-        return new TestPolicy(this, this.directives, newRUles);
+        Map<String, Tag> newRules = new HashMap<String, Tag>(this.tagRules);
+        newRules.put( tag.getName().toLowerCase(), tag);
+        return new TestPolicy(this, this.directives, newRules, cssRules);
     }
 
+    public TestPolicy addCssProperty(Property property) {
+        Map<String, Property> newCssRules = new HashMap<String, Property>(cssRules);
+        newCssRules.put(property.getName().toLowerCase(), property);
+        return new TestPolicy(this, this.directives, tagRules, newCssRules);
+    }
 }


### PR DESCRIPTION
Fixes #125. Overrides `parseStyleDeclaration` on a new `CssParser` class that extends `org.apache.batik.css.parser.Parser`.