### PR TITLE
Add require-closing-tags to default schema and tests

### DIFF
--- a/src/main/resources/antisamy.xsd
+++ b/src/main/resources/antisamy.xsd
@@ -13,7 +13,8 @@
 				<xsd:element name="tags-to-encode" type="TagsToEncodeList" minOccurs="0"/>
 				<xsd:element name="tag-rules" type="TagRules"/>
 				<xsd:element name="css-rules" type="CSSRules"/>
-	        	<xsd:element name="allowed-empty-tags" type="AllowedEmptyTags" minOccurs="0"/>
+				<xsd:element name="allowed-empty-tags" type="LiteralListTag" minOccurs="0"/>
+				<xsd:element name="require-closing-tags" type="LiteralListTag" minOccurs="0"/>
 			</xsd:sequence>
 		</xsd:complexType>
 	</xsd:element>
@@ -65,7 +66,7 @@
 		<xsd:attribute name="action" use="required"/>
 	</xsd:complexType>
 
-    <xsd:complexType name="AllowedEmptyTags">
+    <xsd:complexType name="LiteralListTag">
         <xsd:sequence>
             <xsd:element name="literal-list" type="LiteralList" minOccurs="0"/>
         </xsd:sequence>


### PR DESCRIPTION
- `require-closing-tags` was left out on the default schema. This fixes #147.
- Added some tests for the previous item and others to improve coverage.