### PR TITLE
Use errors list passed to CssHandler constructor

### DIFF
--- a/src/main/java/org/owasp/validator/css/CssHandler.java
+++ b/src/main/java/org/owasp/validator/css/CssHandler.java
@@ -144,7 +144,7 @@ public class CssHandler implements DocumentHandler {
 	 *            the tag name associated with this inline style
 	 */
 	public CssHandler(Policy policy, List<String> errorMessages, ResourceBundle messages, String tagName) {
-		this(policy, null, new ArrayList<String>(), tagName, messages);
+		this(policy, null, errorMessages, tagName, messages);
 	}
 
 	/**

--- a/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007-2021, Arshan Dabirsiaghi, Jason Li
+ * Copyright (c) 2007-2022, Arshan Dabirsiaghi, Jason Li
  *
  * All rights reserved.
  *

--- a/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
@@ -1688,5 +1688,19 @@ static final String test33 = "<html>\n"
             // An error is expected. Pass.
         }
     }
+
+    @Test
+    public void testGithubIssue151() throws ScanException, PolicyException {
+        // Concern is error messages when parsing stylesheets are no longer returned in AntiSamy 1.6.5
+        String input = "<img style=\"FLOAT: right; CURSOR: hand\" src=\"http://site.com/pic.jpg\" />";
+
+        CleanResults result = as.scan(input, policy, AntiSamy.DOM);
+        assertThat(result.getErrorMessages().size(), is(1));
+        assertThat(result.getCleanHTML(), both(containsString("img")).and(not(containsString("CURSOR"))));
+
+        result = as.scan(input, policy, AntiSamy.SAX);
+        assertThat(result.getErrorMessages().size(), is(1));
+        assertThat(result.getCleanHTML(), both(containsString("img")).and(not(containsString("CURSOR"))));
+    }
 }
 


### PR DESCRIPTION
Fixes #151. One of the constructors of `CssHandler` was not using the `errorMessages` list parameter and was creating a new empty list. This resulted in some messages being ignored when using the list by a reference.

The issue was introduced in AntiSamy 1.6.5 release.