### PR TITLE
Upgrade 2x Apache httpcomponent libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <gpg.skip>true</gpg.skip><!-- by default skip gpg -->
         <version.io>2.11.0</version.io>
         <version.slf4j>1.7.36</version.slf4j>
-        <version.spotbugs.maven>4.5.3.0</version.spotbugs.maven>
+        <version.spotbugs.maven>4.6.0.0</version.spotbugs.maven>
         <version.spotbugs>4.6.0</version.spotbugs>
     </properties>
 
@@ -66,30 +66,14 @@
             <version>2.60.0</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
-            <exclusions>
-                <!-- exclude these as httpclient uses older versions of these libraries that we directly import and we want to eliminate the convergence mismatch -->
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-                <!-- exclude obsolete commons-logging in favor of jcl-over-slf4j to ensure logs all pipe through slf4j-api -->
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                   <groupId>org.apache.httpcomponents</groupId>
-                   <artifactId>httpcore</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.1.3</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>4.4.15</version>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+            <version>5.1.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
@@ -198,7 +182,7 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-dependency-plugin</artifactId>
-                  <version>3.2.0</version>
+                  <version>3.3.0</version>
                     <configuration>
                         <usedDependencies>
                             <dependency>commons-io:commons-io</dependency>
@@ -233,7 +217,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.0</version>
+                <version>3.10.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -342,7 +326,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.10.0</version>
+                <version>3.11.0</version>
             </plugin>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
@@ -424,7 +408,7 @@
                     Delete this entire build plugin block in 3.16+ as maven-pmd-plugin is only needed in the reporting block.  -->
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-pmd-plugin</artifactId>
-               <version>3.15.0</version>
+               <version>3.16.0</version>
                <dependencies>
                    <!-- Without this, 3.15.0+ causes lots of warning like: [WARNING] Could not find class org.owasp.validator.html.util.ErrorMessageUtil,
                due to: java.lang.IncompatibleClassChangeError: class net.sourceforge.pmd.lang.java.typeresolution.visitors.PMDASMVisitor
@@ -444,7 +428,7 @@
            <plugin>
                <groupId>org.codehaus.mojo</groupId>
                <artifactId>versions-maven-plugin</artifactId>
-               <version>2.9.0</version>
+               <version>2.10.0</version>
                <reportSets>
                  <reportSet>
                    <reports>
@@ -482,12 +466,12 @@
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-jxr-plugin</artifactId>
-               <version>3.1.1</version>
+               <version>3.2.0</version>
            </plugin>
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-project-info-reports-plugin</artifactId>
-               <version>3.2.1</version>
+               <version>3.2.2</version>
                <reportSets>
                  <reportSet>
                    <reports>


### PR DESCRIPTION
Used from their old 4.x versions to the latest 5.x versions. Required updating imports and rewriting a bit
of code in the CssScanner class.

@davewichers, check if my pom.xml changes seem correct. Basically copy/pasted from 1.6.6 but left some things intact like Java 1.8 usage.