### PR TITLE
Changes for 1.6.6 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>2022-01-31T23:13:00Z</project.build.outputTimestamp>
         <gpg.skip>true</gpg.skip><!-- by default skip gpg -->
-        <!--   The latest commons-io is 2.11.0, but requires Java 8 starting with 2.7  -->
-        <version.io>2.6</version.io>
+        <version.io>2.11.0</version.io>
         <version.slf4j>1.7.36</version.slf4j>
         <version.spotbugs.maven>4.6.0.0</version.spotbugs.maven>
         <version.spotbugs>4.6.0</version.spotbugs>
@@ -76,8 +75,7 @@
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>neko-htmlunit</artifactId>
-            <!-- version 2.25+ requires Java 8 -->
-            <version>2.24</version>
+            <version>2.60.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -279,7 +277,7 @@
                         <configuration>
                             <rules>
                                 <enforceBytecodeVersion>
-                                    <maxJdkVersion>1.7</maxJdkVersion>
+                                    <maxJdkVersion>1.8</maxJdkVersion>
                                     <ignoreOptionals>true</ignoreOptionals>
                                     <ignoredScopes>test</ignoredScopes>
                                     <message>Dependencies shouldn't require Java 8+.</message>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.owasp.antisamy</groupId>
     <artifactId>antisamy</artifactId>
     <packaging>jar</packaging>
-    <version>1.7.0-dev</version>
+    <version>1.6.6-dev</version>
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
@@ -44,9 +44,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>2022-01-31T23:13:00Z</project.build.outputTimestamp>
         <gpg.skip>true</gpg.skip><!-- by default skip gpg -->
-        <version.io>2.11.0</version.io>
+        <!--   The latest commons-io is 2.11.0, but requires Java 8 starting with 2.7  -->
+        <version.io>2.6</version.io>
         <version.slf4j>1.7.36</version.slf4j>
-        <version.spotbugs.maven>4.5.3.0</version.spotbugs.maven>
+        <version.spotbugs.maven>4.6.0.0</version.spotbugs.maven>
         <version.spotbugs>4.6.0</version.spotbugs>
     </properties>
 
@@ -60,17 +61,23 @@
     </profiles>
 
     <dependencies>
-        <dependency>
+        <!-- dependency>
             <groupId>net.sourceforge.nekohtml</groupId>
             <artifactId>nekohtml</artifactId>
             <version>1.9.22</version>
             <exclusions>
-                <!-- exclude this as nekohtml uses an older xercesImpl and we want to eliminate the convergence mismatch -->
+                <! exclude this as nekohtml uses an older xercesImpl and we want to eliminate the convergence mismatch >
                 <exclusion>
                     <groupId>xerces</groupId>
                     <artifactId>xercesImpl</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency -->
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>neko-htmlunit</artifactId>
+            <!-- version 2.25+ requires Java 8 -->
+            <version>2.24</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -272,10 +279,10 @@
                         <configuration>
                             <rules>
                                 <enforceBytecodeVersion>
-                                    <maxJdkVersion>1.8</maxJdkVersion>
+                                    <maxJdkVersion>1.7</maxJdkVersion>
                                     <ignoreOptionals>true</ignoreOptionals>
                                     <ignoredScopes>test</ignoredScopes>
-                                    <message>Dependencies shouldn't require Java 9+.</message>
+                                    <message>Dependencies shouldn't require Java 8+.</message>
                                 </enforceBytecodeVersion>
                                 <requireMavenVersion>
                                     <version>3.3.9</version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,48 +60,20 @@
     </profiles>
 
     <dependencies>
-        <!-- dependency>
-            <groupId>net.sourceforge.nekohtml</groupId>
-            <artifactId>nekohtml</artifactId>
-            <version>1.9.22</version>
-            <exclusions>
-                <! exclude this as nekohtml uses an older xercesImpl and we want to eliminate the convergence mismatch >
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency -->
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>neko-htmlunit</artifactId>
             <version>2.60.0</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
-            <exclusions>
-                <!-- exclude these as httpclient uses older versions of these libraries that we directly import and we want to eliminate the convergence mismatch -->
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-                <!-- exclude obsolete commons-logging in favor of jcl-over-slf4j to ensure logs all pipe through slf4j-api -->
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                   <groupId>org.apache.httpcomponents</groupId>
-                   <artifactId>httpcore</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.1.3</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>4.4.15</version>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+            <version>5.1.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
@@ -280,7 +252,7 @@
                                     <maxJdkVersion>1.8</maxJdkVersion>
                                     <ignoreOptionals>true</ignoreOptionals>
                                     <ignoredScopes>test</ignoredScopes>
-                                    <message>Dependencies shouldn't require Java 8+.</message>
+                                    <message>Dependencies shouldn't require Java 9+.</message>
                                 </enforceBytecodeVersion>
                                 <requireMavenVersion>
                                     <version>3.3.9</version>
@@ -296,7 +268,7 @@
                             <rules>
                                 <requireJavaVersion>
                                     <version>1.7</version>
-                                    <message>Antisamy is written to support Java 7+.</message>
+                                    <message>Antisamy source code is written to support Java 7+.</message>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>

--- a/src/main/java/org/owasp/validator/css/CssHandler.java
+++ b/src/main/java/org/owasp/validator/css/CssHandler.java
@@ -167,7 +167,7 @@ public class CssHandler implements DocumentHandler {
 	 *            the tag name associated with this inline style
 	 */
 	public CssHandler(Policy policy, List<String> errorMessages, ResourceBundle messages, String tagName) {
-		this(policy, null, new ArrayList<String>(), tagName, messages);
+		this(policy, null, errorMessages, tagName, messages);
 	}
 
 	/**

--- a/src/main/java/org/owasp/validator/css/CssScanner.java
+++ b/src/main/java/org/owasp/validator/css/CssScanner.java
@@ -275,6 +275,7 @@ public class CssScanner {
             }
 
             RequestConfig requestConfig = RequestConfig.custom()
+                    .setConnectTimeout(timeout)
                     .setResponseTimeout(timeout)
                     .setConnectionRequestTimeout(timeout)
                     .build();

--- a/src/main/java/org/owasp/validator/css/CssScanner.java
+++ b/src/main/java/org/owasp/validator/css/CssScanner.java
@@ -43,12 +43,17 @@ import java.util.regex.Pattern;
 
 import org.apache.batik.css.parser.ParseException;
 import org.apache.batik.css.parser.Parser;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.client5.http.ClientProtocolException;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.util.Timeout;
 import org.owasp.validator.html.CleanResults;
 import org.owasp.validator.html.InternalPolicy;
 import org.owasp.validator.html.Policy;
@@ -70,7 +75,7 @@ import org.w3c.css.sac.InputSource;
  */
 public class CssScanner {
 
-    protected static final int DEFAULT_TIMEOUT = 1000;
+    protected static final Timeout DEFAULT_TIMEOUT = Timeout.ofMilliseconds(1000);
 
     private static final String CDATA = "^\\s*<!\\[CDATA\\[(.*)\\]\\]>\\s*$";
     
@@ -263,15 +268,14 @@ public class CssScanner {
 
             // Ensure that we have appropriate timeout values so we don't
             // get DoSed waiting for returns
-            int timeout = DEFAULT_TIMEOUT;
+            Timeout timeout = DEFAULT_TIMEOUT;
             try {
-                timeout = Integer.parseInt(policy.getDirective(Policy.CONNECTION_TIMEOUT));
+                timeout = Timeout.ofMilliseconds(Long.parseLong(policy.getDirective(Policy.CONNECTION_TIMEOUT)));
             } catch (NumberFormatException nfe) {
             }
 
             RequestConfig requestConfig = RequestConfig.custom()
-                    .setSocketTimeout(timeout)
-                    .setConnectTimeout(timeout)
+                    .setResponseTimeout(timeout)
                     .setConnectionRequestTimeout(timeout)
                     .build();
 
@@ -302,13 +306,33 @@ public class CssScanner {
                     continue;
                 }
 
-                HttpGet stylesheetRequest = new HttpGet(stylesheetUri);
+                // Pulled directly from: https://github.com/apache/httpcomponents-client/blob/5.1.x/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientWithResponseHandler.java
+                // Create a custom response handler to read in the stylesheet
+                final HttpClientResponseHandler<String> responseHandler = new HttpClientResponseHandler<String>() {
+
+                    @Override
+                    public String handleResponse(
+                            final ClassicHttpResponse response) throws IOException {
+                        final int status = response.getCode();
+                        if (status >= HttpStatus.SC_SUCCESS && status < HttpStatus.SC_REDIRECTION) {
+                            final HttpEntity entity = response.getEntity();
+                            try {
+                                return entity != null ? EntityUtils.toString(entity) : null;
+                            } catch (final ParseException | org.apache.hc.core5.http.ParseException ex) {
+                                throw new ClientProtocolException(ex);
+                            }
+                        } else {
+                            throw new ClientProtocolException("Unexpected response status: " + status);
+                        }
+                    }
+                };
 
                 byte[] stylesheet = null;
+
                 try {
+                    String responseBody = httpClient.execute(new HttpGet(stylesheetUri), responseHandler);
                     // pull down stylesheet, observing size limit
-                    HttpResponse response = httpClient.execute(stylesheetRequest);
-                    stylesheet = EntityUtils.toByteArray(response.getEntity());
+                    stylesheet = responseBody.getBytes();
                     if (stylesheet != null && stylesheet.length > sizeLimit) {
                         errorMessages.add(ErrorMessageUtil.getMessage(
                                 messages,
@@ -323,8 +347,6 @@ public class CssScanner {
                             messages,
                             ErrorMessageUtil.ERROR_CSS_IMPORT_FAILURE,
                             new Object[] { HTMLEntityEncoder.htmlEntityEncode(stylesheetUri.toString()) }));
-                } finally {
-                    stylesheetRequest.releaseConnection();
                 }
 
                 if (stylesheet != null) {

--- a/src/main/java/org/owasp/validator/html/Policy.java
+++ b/src/main/java/org/owasp/validator/html/Policy.java
@@ -146,6 +146,8 @@ public class Policy {
     public static final String PRESERVE_COMMENTS = "preserveComments";
     public static final String ENTITY_ENCODE_INTL_CHARS = "entityEncodeIntlChars";
     public static final String ALLOW_DYNAMIC_ATTRIBUTES = "allowDynamicAttributes";
+    public static final String MAX_INPUT_SIZE = "maxInputSize";
+    public static final String MAX_STYLESHEET_IMPORTS = "maxStyleSheetImports";
 
     public static final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
     public static final String EXTERNAL_PARAM_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";

--- a/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
+++ b/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
@@ -25,7 +25,7 @@ package org.owasp.validator.html.scan;
 
 import org.apache.batik.css.parser.ParseException;
 import org.apache.xerces.dom.DocumentImpl;
-import org.cyberneko.html.parsers.DOMFragmentParser;
+import net.sourceforge.htmlunit.cyberneko.parsers.DOMFragmentParser;
 import org.owasp.validator.css.CssScanner;
 import org.owasp.validator.html.CleanResults;
 import org.owasp.validator.html.Policy;

--- a/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
+++ b/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
@@ -407,10 +407,17 @@ public class AntiSamyDOMScanner extends AbstractAntiSamyScanner {
         CssScanner styleScanner = new CssScanner(policy, messages, policy.isEmbedStyleSheets());
 
         try {
-            Node firstChild = ele.getFirstChild();
-            if (firstChild != null) {
+            if (ele.getChildNodes().getLength() > 0) {
+                String toScan = "";
 
-                String toScan = firstChild.getNodeValue();
+                for (int i = 0; i < ele.getChildNodes().getLength(); i++) {
+                    Node childNode = ele.getChildNodes().item(i);
+                    if (!toScan.isEmpty()){
+                        toScan += "\n";
+                    }
+                    toScan += childNode.getTextContent();
+                }
+
                 CleanResults cr = styleScanner.scanStyleSheet(toScan, policy.getMaxInputSize());
                 errorMessages.addAll(cr.getErrorMessages());
 
@@ -422,12 +429,17 @@ public class AntiSamyDOMScanner extends AbstractAntiSamyScanner {
                  * break all CSS. To prevent that, we have this check.
                  */
 
-                final String cleanHTML = cr.getCleanHTML();
+                String cleanHTML = cr.getCleanHTML();
+                cleanHTML = cleanHTML == null || cleanHTML.equals("") ? "/* */" : cleanHTML;
 
-                if (cleanHTML == null || cleanHTML.equals("")) {
-                    firstChild.setNodeValue("/* */");
-                } else {
-                    firstChild.setNodeValue(cleanHTML);
+                ele.getFirstChild().setNodeValue(cleanHTML);
+                /*
+                 * Remove every other node after cleaning CSS, there will
+                 * be only one node in the end, as it always should have.
+                 */
+                for (int i = 1; i < ele.getChildNodes().getLength(); i++) {
+                    Node childNode = ele.getChildNodes().item(i);
+                    ele.removeChild(childNode);
                 }
             }
 

--- a/src/main/java/org/owasp/validator/html/scan/AntiSamySAXScanner.java
+++ b/src/main/java/org/owasp/validator/html/scan/AntiSamySAXScanner.java
@@ -41,7 +41,7 @@ import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.sax.SAXSource;
 
 import org.apache.xerces.xni.parser.XMLDocumentFilter;
-import org.cyberneko.html.parsers.SAXParser;
+import net.sourceforge.htmlunit.cyberneko.parsers.SAXParser;
 import org.owasp.validator.html.CleanResults;
 import org.owasp.validator.html.Policy;
 import org.owasp.validator.html.ScanException;

--- a/src/main/java/org/owasp/validator/html/scan/MagicSAXFilter.java
+++ b/src/main/java/org/owasp/validator/html/scan/MagicSAXFilter.java
@@ -36,7 +36,7 @@ import org.apache.xerces.xni.XMLAttributes;
 import org.apache.xerces.xni.XMLString;
 import org.apache.xerces.xni.XNIException;
 import org.apache.xerces.xni.parser.XMLDocumentFilter;
-import org.cyberneko.html.filters.DefaultFilter;
+import net.sourceforge.htmlunit.cyberneko.filters.DefaultFilter;
 import org.owasp.validator.css.CssScanner;
 import org.owasp.validator.html.CleanResults;
 import org.owasp.validator.html.InternalPolicy;

--- a/src/main/resources/antisamy.xsd
+++ b/src/main/resources/antisamy.xsd
@@ -13,7 +13,8 @@
 				<xsd:element name="tags-to-encode" type="TagsToEncodeList" minOccurs="0"/>
 				<xsd:element name="tag-rules" type="TagRules"/>
 				<xsd:element name="css-rules" type="CSSRules"/>
-	        	<xsd:element name="allowed-empty-tags" type="AllowedEmptyTags" minOccurs="0"/>
+				<xsd:element name="allowed-empty-tags" type="LiteralListTag" minOccurs="0"/>
+				<xsd:element name="require-closing-tags" type="LiteralListTag" minOccurs="0"/>
 			</xsd:sequence>
 		</xsd:complexType>
 	</xsd:element>
@@ -65,7 +66,7 @@
 		<xsd:attribute name="action" use="required"/>
 	</xsd:complexType>
 
-    <xsd:complexType name="AllowedEmptyTags">
+    <xsd:complexType name="LiteralListTag">
         <xsd:sequence>
             <xsd:element name="literal-list" type="LiteralList" minOccurs="0"/>
         </xsd:sequence>

--- a/src/test/java/org/owasp/validator/css/CssScannerTest.java
+++ b/src/test/java/org/owasp/validator/css/CssScannerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2007-2022, Arshan Dabirsiaghi, Jason Li, Sebastián Passaro
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.  Redistributions in binary form must
+ * reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * Neither the name of OWASP nor the names of its contributors may be used to endorse
+ * or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.owasp.validator.css;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.owasp.validator.html.*;
+import org.owasp.validator.html.scan.Constants;
+import org.owasp.validator.html.test.TestPolicy;
+
+import java.net.URL;
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class CssScannerTest {
+    private TestPolicy policy = null;
+    private ResourceBundle messages = null;
+
+    @Before
+    public void setUp() throws Exception {
+        // Load the policy. You may have to change the path to find the Policy file for your environment.
+        URL url = getClass().getResource("/antisamy.xml");
+        policy = TestPolicy.getInstance(url);
+        // Load resource bundle
+        try {
+            messages = ResourceBundle.getBundle("AntiSamy", Locale.getDefault());
+        } catch (MissingResourceException mre) {
+            messages =  ResourceBundle.getBundle("AntiSamy", new Locale(Constants.DEFAULT_LOCALE_LANG,
+                    Constants.DEFAULT_LOCALE_LOC));
+        }
+    }
+
+    @Test
+    public void testAvoidImportingStyles() throws ScanException {
+        final String input = "@import url(https://raw.githubusercontent.com/nahsra/antisamy/main/src/test/resources/s/slashdot.org_files/classic.css);\n" +
+                ".very-specific-antisamy {font: 15pt \"Arial\"; color: blue;}";
+        // If not passing "shouldParseImportedStyles" then it's false by default.
+        CssScanner scanner = new CssScanner(policy, messages);
+        String result = scanner.scanStyleSheet(input, 1000).getCleanHTML();
+        // If style sheet was imported, .grid_1 class should be there.
+        assertThat(result, not(containsString(".grid_1")));
+        assertThat(result, containsString(".very-specific-antisamy"));
+    }
+
+    @Test
+    public void testAvoidCdataWhenUsingXhtml() throws ScanException {
+        final String input = "<![CDATA[.very-specific-antisamy {font: 15pt \"Arial\"; color: blue;}]]>";
+
+        TestPolicy revised = policy.cloneWithDirective(Policy.USE_XHTML,"true");
+        CssScanner scanner = new CssScanner(revised, messages);
+        assertThat(scanner.scanStyleSheet(input, 1000).getCleanHTML(), not(containsString("CDATA")));
+
+        revised = policy.cloneWithDirective(Policy.USE_XHTML,"false");
+        scanner = new CssScanner(revised, messages);
+        assertThat(scanner.scanStyleSheet(input, 1000).getCleanHTML(), containsString("CDATA"));
+    }
+
+    @Test
+    public void testImportLimiting() throws ScanException {
+        final String input = "@import url(https://raw.githubusercontent.com/nahsra/antisamy/main/src/test/resources/s/slashdot.org_files/classic.css);\n" +
+                "@import url(https://raw.githubusercontent.com/nahsra/antisamy/main/src/test/resources/s/slashdot.org_files/providers.css);\n" +
+                ".very-specific-antisamy {font: 15pt \"Arial\"; color: blue;}";
+        TestPolicy revised = policy.cloneWithDirective(Policy.EMBED_STYLESHEETS,"true")
+                .cloneWithDirective(Policy.MAX_INPUT_SIZE,"500")
+                .cloneWithDirective(Policy.MAX_STYLESHEET_IMPORTS,"2");
+        CssScanner scanner = new CssScanner(revised, messages, true);
+        CleanResults result = scanner.scanStyleSheet(input, 500);
+        // Both sheets are larger than 500 bytes
+        assertThat(result.getErrorMessages().size(), is(2));
+        assertThat(result.getErrorMessages().get(0), containsString("500"));
+
+        // Limit to only one import
+        revised = policy.cloneWithDirective(Policy.EMBED_STYLESHEETS,"true")
+                .cloneWithDirective(Policy.MAX_STYLESHEET_IMPORTS,"1");
+        scanner = new CssScanner(revised, messages, true);
+        result = scanner.scanStyleSheet(input, 500000);
+        // If only first style sheet was imported, .grid_1 class should be there and .janrain-provider150-sprit classes should not.
+        assertThat(result.getCleanHTML(), containsString(".grid_1"));
+        assertThat(result.getCleanHTML(), not(containsString(".janrain-provider150-sprit")));
+
+        // Force timeout errors
+        revised = policy.cloneWithDirective(Policy.EMBED_STYLESHEETS,"true")
+                .cloneWithDirective(Policy.CONNECTION_TIMEOUT,"1");
+        scanner = new CssScanner(revised, messages, true);
+        result = scanner.scanStyleSheet(input, 500000);
+        assertThat(result.getErrorMessages().size(), is(2));
+        // If style sheets were imported, .grid_1 and .janrain-provider150-sprit classes should be there.
+        assertThat(result.getCleanHTML(), not(containsString(".grid_1")));
+        assertThat(result.getCleanHTML(), not(containsString(".janrain-provider150-sprit")));
+    }
+}

--- a/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
@@ -1511,11 +1511,13 @@ static final String test33 = "<html>\n"
         // Concern is that "&" is not being encoded and "#00058" was not being interpreted as ":"
         // so the validations based on regexp passed and a browser would load "&:" together.
         // All this when not using the XHTML serializer.
+
+        // UPDATE: Using a new HTML parser library starts decoding entities like #00058
         Policy revised = policy.cloneWithDirective("useXHTML","false");
         assertThat(as.scan("<p><a href=\"javascript&#00058x=1,%61%6c%65%72%74%28%22%62%6f%6f%6d%22%29\">xss</a></p>", revised, AntiSamy.DOM).getCleanHTML(),
-                containsString("javascript&amp;#00058"));
+                not(containsString("javascript")));
         assertThat(as.scan("<p><a href=\"javascript&#00058x=1,%61%6c%65%72%74%28%22%62%6f%6f%6d%22%29\">xss</a></p>", revised, AntiSamy.SAX).getCleanHTML(),
-                containsString("javascript&amp;#00058"));
+                not(containsString("javascript")));
     }
 
     @Test
@@ -1715,6 +1717,19 @@ static final String test33 = "<html>\n"
         Policy revised2 = policy.cloneWithDirective(Policy.USE_XHTML,"false");
         assertThat(as.scan("<select<style/>W<xmp<script>alert(1)</script>", revised2, AntiSamy.DOM).getCleanHTML(), not(containsString("script")));
         assertThat(as.scan("<select<style/>W<xmp<script>alert(1)</script>", revised2, AntiSamy.SAX).getCleanHTML(), not(containsString("script")));
+    }
+
+    @Test(timeout = 3000)
+    public void testMalformedPIScan() {
+        // Certain malformed input including a malformed processing instruction may lead the parser to an internal memory error.
+        try {
+            as.scan("<!--><?a/", policy, AntiSamy.DOM).getCleanHTML();
+            as.scan("<!--><?a/", policy, AntiSamy.SAX).getCleanHTML();
+        } catch (ScanException ex) {
+            // It is OK, internal parser should fail.
+        } catch (Exception ex) {
+            fail("Parser should not throw a non-ScanException");
+        }
     }
 }
 

--- a/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
@@ -1702,5 +1702,19 @@ static final String test33 = "<html>\n"
         assertThat(result.getErrorMessages().size(), is(1));
         assertThat(result.getCleanHTML(), both(containsString("img")).and(not(containsString("CURSOR"))));
     }
+
+    @Test
+    public void testSmuggledTagsInStyleContent() throws ScanException, PolicyException {
+        // HTML tags may be smuggled into a style tag after parsing input to an internal representation.
+        // If that happens, they should be treated as text content and not as children nodes.
+
+        Policy revised = policy.cloneWithDirective(Policy.USE_XHTML,"true");
+        assertThat(as.scan("<style/>b<![cdata[</style><a href=javascript:alert(1)>test", revised, AntiSamy.DOM).getCleanHTML(), not(containsString("javascript")));
+        assertThat(as.scan("<style/>b<![cdata[</style><a href=javascript:alert(1)>test", revised, AntiSamy.SAX).getCleanHTML(), not(containsString("javascript")));
+
+        Policy revised2 = policy.cloneWithDirective(Policy.USE_XHTML,"false");
+        assertThat(as.scan("<select<style/>W<xmp<script>alert(1)</script>", revised2, AntiSamy.DOM).getCleanHTML(), not(containsString("script")));
+        assertThat(as.scan("<select<style/>W<xmp<script>alert(1)</script>", revised2, AntiSamy.SAX).getCleanHTML(), not(containsString("script")));
+    }
 }
 

--- a/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007-2021, Arshan Dabirsiaghi, Jason Li
+ * Copyright (c) 2007-2022, Arshan Dabirsiaghi, Jason Li
  *
  * All rights reserved.
  *

--- a/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
@@ -44,11 +44,13 @@ import org.hamcrest.text.MatchesPattern;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/org/owasp/validator/html/test/PolicyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/PolicyTest.java
@@ -72,9 +72,9 @@ public class PolicyTest {
     private static final String FOOTER = "</anti-samy-rules>";
 
     // Returns a valid policy file with the specified allowedEmptyTags
-    private String assembleFile(String allowedEmptyTagsSection) {
+    private String assembleFile(String finalTagsSection) {
         return HEADER + DIRECTIVES + COMMON_REGEXPS + COMMON_ATTRIBUTES + GLOBAL_TAG_ATTRIBUTES + DYNAMIC_TAG_ATTRIBUTES + TAG_RULES + CSS_RULES +
-               allowedEmptyTagsSection + FOOTER;
+                finalTagsSection + FOOTER;
     }
 
     @Before
@@ -126,14 +126,64 @@ public class PolicyTest {
     @Test
     public void testGetAllowedEmptyTags_NoSection() throws PolicyException {
         String allowedEmptyTagsSection = "";
-
         String policyFile = assembleFile(allowedEmptyTagsSection);
 
         policy = Policy.getInstance(new ByteArrayInputStream(policyFile.getBytes()));
 
         assertTrue(policy.getAllowedEmptyTags().size() == Constants.defaultAllowedEmptyTags.size());
     }
-    
+
+    @Test
+    public void testGetRequireClosingTags() throws PolicyException {
+        String requireClosingTagsSection = "<require-closing-tags>\n" +
+                "    <literal-list>\n" +
+                "                <literal value=\"td\"/>\n" +
+                "                <literal value=\"span\"/>\n" +
+                "    </literal-list>\n" +
+                "</require-closing-tags>\n";
+        String policyFile = assembleFile(requireClosingTagsSection);
+
+        policy = Policy.getInstance(new ByteArrayInputStream(policyFile.getBytes()));
+
+        TagMatcher actualTags = policy.getRequiresClosingTags();
+
+        assertTrue(actualTags.matches("td"));
+        assertTrue(actualTags.matches("span"));
+    }
+
+    @Test
+    public void testGetRequireClosingTags_emptyList() throws PolicyException {
+        String requireClosingTagsSection = "<require-closing-tags>\n" +
+                "    <literal-list>\n" +
+                "    </literal-list>\n" +
+                "</require-closing-tags>\n";
+        String policyFile = assembleFile(requireClosingTagsSection);
+
+        policy = Policy.getInstance(new ByteArrayInputStream(policyFile.getBytes()));
+
+        assertEquals(0, policy.getRequiresClosingTags().size());
+    }
+
+    @Test
+    public void testGetRequireClosingTags_emptySection() throws PolicyException {
+        String requireClosingTagsSection = "<require-closing-tags>\n" + "</require-closing-tags>\n";
+        String policyFile = assembleFile(requireClosingTagsSection);
+
+        policy = Policy.getInstance(new ByteArrayInputStream(policyFile.getBytes()));
+
+        assertEquals(0, policy.getRequiresClosingTags().size());
+    }
+
+    @Test
+    public void testGetRequireClosingTags_NoSection() throws PolicyException {
+        String requireClosingTagsSection = "";
+        String policyFile = assembleFile(requireClosingTagsSection);
+
+        policy = Policy.getInstance(new ByteArrayInputStream(policyFile.getBytes()));
+
+        assertTrue(policy.getRequiresClosingTags().size() == Constants.defaultRequireClosingTags.size());
+    }
+
     @Test
     public void testInvalidPolicies() {
         // Default is to now enforce schema validation on policy files.
@@ -293,6 +343,24 @@ public class PolicyTest {
         } catch (PolicyException e) {
             assertNotNull(e);
         }
+    }
+
+    @Test
+    public void testSchemaValidationWithOptionallyDefinedTags() throws PolicyException {
+        String allowedEmptyTagsSection = "<allowed-empty-tags>\n" +
+                "    <literal-list>\n" +
+                "                <literal value=\"span\"/>\n" +
+                "    </literal-list>\n" +
+                "</allowed-empty-tags>\n";
+        String requireClosingTagsSection = "<require-closing-tags>\n" +
+                "    <literal-list>\n" +
+                "                <literal value=\"span\"/>\n" +
+                "    </literal-list>\n" +
+                "</require-closing-tags>\n";
+        String policyFile = assembleFile(allowedEmptyTagsSection + requireClosingTagsSection);
+
+        policy = Policy.getInstance(new ByteArrayInputStream(policyFile.getBytes()));
+        // If it reaches this point, it passed schema validation, which is what we want.
     }
 
     @Test

--- a/src/test/java/org/owasp/validator/html/test/TestPolicy.java
+++ b/src/test/java/org/owasp/validator/html/test/TestPolicy.java
@@ -43,7 +43,7 @@ import org.owasp.validator.html.model.Tag;
  */
 public class TestPolicy extends InternalPolicy {
 
-    protected TestPolicy(Policy.ParseContext parseContext) throws PolicyException {
+    protected TestPolicy(Policy.ParseContext parseContext) {
         super(parseContext);
     }
 


### PR DESCRIPTION
- Update NekoHTML and other dependencies to work with Java 8.
- Add require-closing-tags to default schema.
- Add deprecated annotations for XHTML.
- Support multiple children handling on `style` tags.
- Improve test coverage.