### PR TITLE
Fix paragraph regex

### DIFF
--- a/src/main/resources/antisamy-anythinggoes.xml
+++ b/src/main/resources/antisamy-anythinggoes.xml
@@ -33,7 +33,7 @@
 
         <regexp name="anything" value=".*" />
         <regexp name="numberOrPercent" value="(\d)+(%{0,1})" />
-        <regexp name="paragraph" value="([\p{L}\p{N},'\.\s\-_\(\)]|&amp;[0-9]{2};)*" />
+        <regexp name="paragraph" value="[\p{L}\p{N},'.\s\-_\(\)&amp;;]*" />
         <regexp name="htmlId" value="[a-zA-Z0-9\:\-_\.]+" />
         <regexp name="htmlTitle" value="[\p{L}\p{N}\s\-_',:\[\]!\./\\\(\)&amp;]*" /> <!-- force non-empty with a '+' at the end instead of '*' -->
         <regexp name="htmlClass" value="[a-zA-Z0-9\s,\-_]+" />

--- a/src/main/resources/antisamy-ebay.xml
+++ b/src/main/resources/antisamy-ebay.xml
@@ -31,7 +31,7 @@
 
         <regexp name="anything" value=".*" />
         <regexp name="numberOrPercent" value="(\d)+(%{0,1})" />
-        <regexp name="paragraph" value="([\p{L}\p{N},'\.\s\-_\(\)]|&amp;[0-9]{2};)*" />
+        <regexp name="paragraph" value="[\p{L}\p{N},'.\s\-_\(\)&amp;;]*" />
         <regexp name="htmlId" value="[a-zA-Z0-9\:\-_\.]+" />
         <regexp name="htmlTitle" value="[\p{L}\p{N}\s\-_',:\[\]!\./\\\(\)&amp;]*" /> <!-- force non-empty with a '+' at the end instead of '*' -->
         <regexp name="htmlClass" value="[a-zA-Z0-9\s,\-_]+" />

--- a/src/main/resources/antisamy-myspace.xml
+++ b/src/main/resources/antisamy-myspace.xml
@@ -33,7 +33,7 @@
 
         <regexp name="anything" value=".*" />
         <regexp name="numberOrPercent" value="(\d)+(%{0,1})" />
-        <regexp name="paragraph" value="([\p{L}\p{N},'\.\s\-_\(\)]|&amp;[0-9]{2};)*" />
+        <regexp name="paragraph" value="[\p{L}\p{N},'.\s\-_\(\)&amp;;]*" />
         <regexp name="htmlId" value="[a-zA-Z0-9\:\-_\.]+" />
         <regexp name="htmlTitle" value="[\p{L}\p{N}\s\-_',:\[\]!\./\\\(\)&amp;]*" /> <!-- force non-empty with a '+' at the end instead of '*' -->
         <regexp name="htmlClass" value="[a-zA-Z0-9\s,\-_]+" />

--- a/src/main/resources/antisamy.xml
+++ b/src/main/resources/antisamy.xml
@@ -36,7 +36,7 @@
 
         <regexp name="anything" value=".*" />
         <regexp name="numberOrPercent" value="(\d)+(%{0,1})" />
-        <regexp name="paragraph" value="([\p{L}\p{N},'\.\s\-_\(\)]|&amp;[0-9]{2};)*" />
+        <regexp name="paragraph" value="[\p{L}\p{N},'.\s\-_\(\)&amp;;]*" />
         <regexp name="htmlId" value="[a-zA-Z0-9\:\-_\.]+" />
         <regexp name="htmlTitle" value="[\p{L}\p{N}\s\-_',:\[\]!\./\\\(\)&amp;]*" /> <!-- force non-empty with a '+' at the end instead of '*' -->
         <regexp name="htmlClass" value="[a-zA-Z0-9\s,\-_]+" />

--- a/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
@@ -2621,4 +2621,20 @@ public class AntiSamyTest {
           as.scan(payload, revised, AntiSamy.SAX).getCleanHTML(), not(containsString("mxss")));
     }
   }
+
+  @Test
+  public void testRegexStackOverflow() throws ScanException, PolicyException {
+    try {
+      String input =
+          "<img border=\"0\" width=\"320\" height=\"200\" style=\"width:3.368in;height:2.0486in\" id=\"id_123\" src=\"/url/uri\" alt=\"";
+      for (int i = 0; i < 2500; i++) {
+        input += "SampleText ";
+      }
+      input += "!\\\">";
+      as.scan(input, policy, AntiSamy.DOM).getCleanHTML();
+      as.scan(input, policy, AntiSamy.SAX).getCleanHTML();
+    } catch (StackOverflowError e) {
+      fail("Parser should not throw a stack overflow error");
+    }
+  }
 }


### PR DESCRIPTION
Discussed on issue #402, regex for `paragraph` in attributes format could be improved preserving allowed characters.