### PR TITLE
add support for inline style css functions

### DIFF
--- a/src/main/java/org/owasp/validator/css/CssValidator.java
+++ b/src/main/java/org/owasp/validator/css/CssValidator.java
@@ -361,10 +361,23 @@ public class CssValidator {
         return "inherit";
       case LexicalUnit.SAC_OPERATOR_COMMA:
         return ",";
+      case LexicalUnit.SAC_FUNCTION:
+        final StringBuffer builder = new StringBuffer();
+        builder.append(lu.getFunctionName());
+        builder.append("(");
+        LexicalUnit params = lu.getParameters();
+        while (params != null) {
+          builder.append(lexicalValueToString(params));
+          params = params.getNextLexicalUnit();
+          if (params != null) {
+            builder.append(", ");
+          }
+        }
+        builder.append(")");
+        return builder.toString();
       case LexicalUnit.SAC_ATTR:
       case LexicalUnit.SAC_COUNTER_FUNCTION:
       case LexicalUnit.SAC_COUNTERS_FUNCTION:
-      case LexicalUnit.SAC_FUNCTION:
       case LexicalUnit.SAC_RECT_FUNCTION:
       case LexicalUnit.SAC_SUB_EXPRESSION:
       case LexicalUnit.SAC_UNICODERANGE:

--- a/src/main/java/org/owasp/validator/css/CssValidator.java
+++ b/src/main/java/org/owasp/validator/css/CssValidator.java
@@ -333,20 +333,13 @@ public class CssValidator {
         return String.valueOf(lu.getFloatValue());
       case LexicalUnit.SAC_STRING_VALUE:
       case LexicalUnit.SAC_IDENT:
-        // Ensure that JavaScript URLs are not allowed
+        // just a string/identifier
         String stringValue = lu.getStringValue();
-        if (stringValue == null || stringValue.toLowerCase().startsWith("javascript:")) {
-          return null;
-        }
         if (stringValue.indexOf(" ") != -1) stringValue = "'" + stringValue + "'";
         return stringValue;
       case LexicalUnit.SAC_URI:
-        // Ensure that JavaScript URLs are not allowed
-        String url = lu.getStringValue();
-        if (url == null || url.toLowerCase().startsWith("javascript:")) {
-          return null;
-        }
-        return "url(" + url + ")";
+        // this is a URL
+        return "url(" + lu.getStringValue() + ")";
       case LexicalUnit.SAC_RGBCOLOR:
         // this is a rgb encoded color
         StringBuffer sb = new StringBuffer("rgb(");

--- a/src/test/java/org/owasp/validator/css/CssValidatorTest.java
+++ b/src/test/java/org/owasp/validator/css/CssValidatorTest.java
@@ -1,51 +1,142 @@
 package org.owasp.validator.css;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.apache.batik.css.parser.CSSLexicalUnit;
 import org.junit.Test;
 import org.w3c.css.sac.LexicalUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
 public class CssValidatorTest {
-    @Test
-    public void testLexicalValueToStringSacFunction() {
-        CssValidator cssValidator = new CssValidator(null);
+  @Test
+  public void testLexicalValueToStringSacFunction() {
+    CssValidator cssValidator = new CssValidator(null);
 
-        final CSSLexicalUnit param =
-                CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "--ds-text-purple", null);
-        final CSSLexicalUnit varFunc = CSSLexicalUnit.createFunction("var", param, null);
+    final CSSLexicalUnit param =
+        CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "--ds-text-purple", null);
+    final CSSLexicalUnit varFunc = CSSLexicalUnit.createFunction("var", param, null);
 
-        assertEquals("var(--ds-text-purple)", cssValidator.lexicalValueToString(varFunc));
+    assertEquals("var(--ds-text-purple)", cssValidator.lexicalValueToString(varFunc));
 
-        final CSSLexicalUnit hslaParam = CSSLexicalUnit.createInteger(100, null);
-        final CSSLexicalUnit hslaParam1 = CSSLexicalUnit.createDimension(98, "%", hslaParam);
-        final CSSLexicalUnit hslaParam2 = CSSLexicalUnit.createDimension(50, "%", hslaParam1);
-        CSSLexicalUnit.createFloat(LexicalUnit.SAC_REAL, 0.3f, hslaParam2);
+    final CSSLexicalUnit hslaParam = CSSLexicalUnit.createInteger(100, null);
+    final CSSLexicalUnit hslaParam1 = CSSLexicalUnit.createDimension(98, "%", hslaParam);
+    final CSSLexicalUnit hslaParam2 = CSSLexicalUnit.createDimension(50, "%", hslaParam1);
+    CSSLexicalUnit.createFloat(LexicalUnit.SAC_REAL, 0.3f, hslaParam2);
 
-        final CSSLexicalUnit hslaFunc = CSSLexicalUnit.createFunction("hsla", hslaParam, null);
-        assertEquals("hsla(100, 98.0%, 50.0%, 0.3)", cssValidator.lexicalValueToString(hslaFunc));
-    }
+    final CSSLexicalUnit hslaFunc = CSSLexicalUnit.createFunction("hsla", hslaParam, null);
+    assertEquals("hsla(100, 98.0%, 50.0%, 0.3)", cssValidator.lexicalValueToString(hslaFunc));
+  }
 
-    @Test
-    public void testLexicalValueToStringSacFunctionTwoParams() {
-        CssValidator cssValidator = new CssValidator(null);
+  @Test
+  public void testLexicalValueToStringSacFunctionTwoParams() {
+    CssValidator cssValidator = new CssValidator(null);
 
-        final CSSLexicalUnit param =
-                CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "--ds-text-purple", null);
-        CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "#FFFFFF", param);
-        final CSSLexicalUnit func = CSSLexicalUnit.createFunction("var", param, null);
+    final CSSLexicalUnit param =
+        CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "--ds-text-purple", null);
+    CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "#FFFFFF", param);
+    final CSSLexicalUnit func = CSSLexicalUnit.createFunction("var", param, null);
 
-        assertEquals("var(--ds-text-purple, #FFFFFF)", cssValidator.lexicalValueToString(func));
-    }
+    assertEquals("var(--ds-text-purple, #FFFFFF)", cssValidator.lexicalValueToString(func));
+  }
 
-    @Test
-    public void testLexicalValueToStringUnsupported() {
-        CssValidator cssValidator = new CssValidator(null);
-        final CSSLexicalUnit param =
-                CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "section", null);
-        final CSSLexicalUnit func =
-                CSSLexicalUnit.createPredefinedFunction(LexicalUnit.SAC_COUNTER_FUNCTION, param, null);
-        assertNull(cssValidator.lexicalValueToString(func));
-    }
+  @Test
+  public void testLexicalValueToStringUnsupported() {
+    CssValidator cssValidator = new CssValidator(null);
+    final CSSLexicalUnit param =
+        CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "section", null);
+    final CSSLexicalUnit func =
+        CSSLexicalUnit.createPredefinedFunction(LexicalUnit.SAC_COUNTER_FUNCTION, param, null);
+    assertNull(cssValidator.lexicalValueToString(func));
+  }
+
+  @Test
+  public void testLexicalValueToStringNestedVarsWithFallback() {
+    CssValidator cssValidator = new CssValidator(null);
+
+    // Create fallback first: --ds-text-purple, #FFFFFF
+    final CSSLexicalUnit param =
+        CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "--ds-text-purple", null);
+    final CSSLexicalUnit fallback =
+        CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "#FFFFFF", null);
+
+    // Create first var() function with fallback
+    final CSSLexicalUnit function = CSSLexicalUnit.createFunction("var", param, fallback);
+
+    // Check if the output is as expected for first var()
+    assertEquals("var(--ds-text-purple, #FFFFFF)", cssValidator.lexicalValueToString(function));
+
+    // Create outer variable: --custom-prop
+    final CSSLexicalUnit outerParam =
+        CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "--custom-prop", null);
+
+    // Create outer var() with the first function as fallback
+    final CSSLexicalUnit outerFunction = CSSLexicalUnit.createFunction("var", outerParam, function);
+
+    // Ensure the output is as expected for the nested var() function
+    assertEquals(
+        "var(--custom-prop, var(--ds-text-purple, #FFFFFF))",
+        cssValidator.lexicalValueToString(outerFunction));
+  }
+
+  @Test
+  public void testDefaultPolicyUrlFunction() {
+    CssValidator cssValidator = new CssValidator(null);
+
+    // Test a simple url function
+    final CSSLexicalUnit urlParam =
+        CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "http://example.com", null);
+    final CSSLexicalUnit urlFunc = CSSLexicalUnit.createFunction("url", urlParam, null);
+
+    assertEquals("url(http://example.com)", cssValidator.lexicalValueToString(urlFunc));
+  }
+
+  @Test
+  public void testDefaultPolicyUrlFunctionWithJavaScript() {
+    CssValidator cssValidator = new CssValidator(null);
+
+    // Test a url function with a JavaScript URL
+    final CSSLexicalUnit urlParam =
+        CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "javascript:alert(1)", null);
+    final CSSLexicalUnit urlFunc = CSSLexicalUnit.createFunction("url", urlParam, null);
+
+    // Ensure that JavaScript URLs are not allowed
+    assertNull(cssValidator.lexicalValueToString(urlFunc));
+  }
+
+  @Test
+  public void testLexicalValueToStringNestedVarsWithJavaScriptAsFallback() {
+    CssValidator cssValidator = new CssValidator(null);
+
+    // Create fallback first: --ds-text-purple, #FFFFFF
+    final CSSLexicalUnit param =
+        CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "--custom-url", null);
+    final CSSLexicalUnit fallback =
+        CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "javascript:alert(1)", null);
+
+    // Create first var() function with fallback
+    final CSSLexicalUnit function = CSSLexicalUnit.createFunction("var", param, fallback);
+
+    // Check if the output is as expected for first var()
+    assertNull(cssValidator.lexicalValueToString(function));
+  }
+
+  @Test
+  public void testSacUriWithJavaScriptUrl() {
+    CssValidator cssValidator = new CssValidator(null);
+
+    // Test with a JavaScript URL, which should be blocked
+    final CSSLexicalUnit jsUrl =
+        CSSLexicalUnit.createString(LexicalUnit.SAC_URI, "javascript:alert(1)", null);
+    assertNull("JavaScript URL should be blocked", cssValidator.lexicalValueToString(jsUrl));
+  }
+
+  @Test
+  public void testSacUriWithValidUrl() {
+    CssValidator cssValidator = new CssValidator(null);
+
+    // Test with a valid URL, which should be allowed
+    final CSSLexicalUnit validUrl =
+        CSSLexicalUnit.createString(LexicalUnit.SAC_URI, "https://example.com", null);
+    assertEquals("url(https://example.com)", cssValidator.lexicalValueToString(validUrl));
+  }
 }

--- a/src/test/java/org/owasp/validator/css/CssValidatorTest.java
+++ b/src/test/java/org/owasp/validator/css/CssValidatorTest.java
@@ -1,0 +1,51 @@
+package org.owasp.validator.css;
+
+import org.apache.batik.css.parser.CSSLexicalUnit;
+import org.junit.Test;
+import org.w3c.css.sac.LexicalUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class CssValidatorTest {
+    @Test
+    public void testLexicalValueToStringSacFunction() {
+        CssValidator cssValidator = new CssValidator(null);
+
+        final CSSLexicalUnit param =
+                CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "--ds-text-purple", null);
+        final CSSLexicalUnit varFunc = CSSLexicalUnit.createFunction("var", param, null);
+
+        assertEquals("var(--ds-text-purple)", cssValidator.lexicalValueToString(varFunc));
+
+        final CSSLexicalUnit hslaParam = CSSLexicalUnit.createInteger(100, null);
+        final CSSLexicalUnit hslaParam1 = CSSLexicalUnit.createDimension(98, "%", hslaParam);
+        final CSSLexicalUnit hslaParam2 = CSSLexicalUnit.createDimension(50, "%", hslaParam1);
+        CSSLexicalUnit.createFloat(LexicalUnit.SAC_REAL, 0.3f, hslaParam2);
+
+        final CSSLexicalUnit hslaFunc = CSSLexicalUnit.createFunction("hsla", hslaParam, null);
+        assertEquals("hsla(100, 98.0%, 50.0%, 0.3)", cssValidator.lexicalValueToString(hslaFunc));
+    }
+
+    @Test
+    public void testLexicalValueToStringSacFunctionTwoParams() {
+        CssValidator cssValidator = new CssValidator(null);
+
+        final CSSLexicalUnit param =
+                CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "--ds-text-purple", null);
+        CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "#FFFFFF", param);
+        final CSSLexicalUnit func = CSSLexicalUnit.createFunction("var", param, null);
+
+        assertEquals("var(--ds-text-purple, #FFFFFF)", cssValidator.lexicalValueToString(func));
+    }
+
+    @Test
+    public void testLexicalValueToStringUnsupported() {
+        CssValidator cssValidator = new CssValidator(null);
+        final CSSLexicalUnit param =
+                CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "section", null);
+        final CSSLexicalUnit func =
+                CSSLexicalUnit.createPredefinedFunction(LexicalUnit.SAC_COUNTER_FUNCTION, param, null);
+        assertNull(cssValidator.lexicalValueToString(func));
+    }
+}

--- a/src/test/java/org/owasp/validator/css/CssValidatorTest.java
+++ b/src/test/java/org/owasp/validator/css/CssValidatorTest.java
@@ -91,46 +91,6 @@ public class CssValidatorTest {
   }
 
   @Test
-  public void testDefaultPolicyUrlFunctionWithJavaScript() {
-    CssValidator cssValidator = new CssValidator(null);
-
-    // Test a url function with a JavaScript URL
-    final CSSLexicalUnit urlParam =
-        CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "javascript:alert(1)", null);
-    final CSSLexicalUnit urlFunc = CSSLexicalUnit.createFunction("url", urlParam, null);
-
-    // Ensure that JavaScript URLs are not allowed
-    assertNull(cssValidator.lexicalValueToString(urlFunc));
-  }
-
-  @Test
-  public void testLexicalValueToStringNestedVarsWithJavaScriptAsFallback() {
-    CssValidator cssValidator = new CssValidator(null);
-
-    // Create fallback first: --ds-text-purple, #FFFFFF
-    final CSSLexicalUnit param =
-        CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "--custom-url", null);
-    final CSSLexicalUnit fallback =
-        CSSLexicalUnit.createString(LexicalUnit.SAC_STRING_VALUE, "javascript:alert(1)", null);
-
-    // Create first var() function with fallback
-    final CSSLexicalUnit function = CSSLexicalUnit.createFunction("var", param, fallback);
-
-    // Check if the output is as expected for first var()
-    assertNull(cssValidator.lexicalValueToString(function));
-  }
-
-  @Test
-  public void testSacUriWithJavaScriptUrl() {
-    CssValidator cssValidator = new CssValidator(null);
-
-    // Test with a JavaScript URL, which should be blocked
-    final CSSLexicalUnit jsUrl =
-        CSSLexicalUnit.createString(LexicalUnit.SAC_URI, "javascript:alert(1)", null);
-    assertNull("JavaScript URL should be blocked", cssValidator.lexicalValueToString(jsUrl));
-  }
-
-  @Test
   public void testSacUriWithValidUrl() {
     CssValidator cssValidator = new CssValidator(null);
 


### PR DESCRIPTION
Custom `style` attributes are stripped from the output and not applied. We need to support inline style css functions for our use-case. 
adding support for the var(...)  css function.
Details can be found at https://jira.atlassian.com/browse/CONFCLOUD-77050
Added tests as well