### PR TITLE
Fix `rel` being duplicated with SAX parser when it is first attribute

### DIFF
--- a/src/main/java/org/owasp/validator/html/scan/MagicSAXFilter.java
+++ b/src/main/java/org/owasp/validator/html/scan/MagicSAXFilter.java
@@ -434,7 +434,7 @@ public class MagicSAXFilter extends DefaultFilter implements XMLDocumentFilter {
                   addNofollow, addNoopenerAndNoreferrer, currentRelValue);
           if (!relValue.isEmpty()) {
             int relIndex;
-            if ((relIndex = validattributes.getIndex("rel")) > 0) {
+            if ((relIndex = validattributes.getIndex("rel")) >= 0) {
               validattributes.setValue(relIndex, relValue);
             } else {
               validattributes.addAttribute(makeSimpleQname("rel"), "CDATA", relValue);

--- a/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
@@ -2906,4 +2906,16 @@ public class AntiSamyTest {
     assertEquals(expectedCleanHtml, crDom.getCleanHTML());
     assertEquals(expectedCleanHtml, crSax.getCleanHTML());
   }
+
+  @Test
+  public void testGithubIssue587() throws ScanException, PolicyException {
+    // "rel" attribute with SAX parser was being duplicated when it was already present at the beginning
+    // of the attribute list. Fix checks the correct index before processing.
+    String output = as.scan("<a rel='nofollow' target='_blank'>Link text</a>", policy, AntiSamy.DOM)
+            .getCleanHTML();
+    assertThat(output.split("rel=").length - 1, is(1));
+    output = as.scan("<a rel='nofollow' target='_blank'>Link text</a>", policy, AntiSamy.SAX)
+            .getCleanHTML();
+    assertThat(output.split("rel=").length - 1, is(1));
+  }
 }


### PR DESCRIPTION
Fixes issue described in #587 with the proposed solution. Adds tests for the specific case.