### PR TITLE
fix: ASHTMLSerializer silently drops comment nodes

### DIFF
--- a/src/main/java/org/owasp/validator/html/scan/ASHTMLSerializer.java
+++ b/src/main/java/org/owasp/validator/html/scan/ASHTMLSerializer.java
@@ -3,6 +3,7 @@ package org.owasp.validator.html.scan;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Locale;
+
 import org.apache.xml.serialize.ElementState;
 import org.apache.xml.serialize.HTMLdtd;
 import org.apache.xml.serialize.OutputFormat;
@@ -11,6 +12,7 @@ import org.owasp.validator.html.TagMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Attr;
+import org.w3c.dom.Comment;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -35,6 +37,25 @@ public class ASHTMLSerializer extends org.apache.xml.serialize.HTMLSerializer {
     if (encodeAllPossibleEntities || Constants.big5CharsToEncode.indexOf(charToPrint) != -1)
       return super.getEntityRef(charToPrint);
     return null;
+  }
+
+  /**
+   * Overrides the base class to fix a bug where comment nodes that are direct children of a
+   * DocumentFragment (i.e. at the document root level) are silently dropped even when
+   * preserveComments=true. The Xerces HTMLSerializer only handles COMMENT_NODE inside element
+   * serialization, never when isDocumentState() is true. We intercept comment nodes here and
+   * print them directly; all other node types fall through to the base implementation.
+   */
+  @Override
+  protected void serializeNode(Node node) throws IOException {
+    if (node.getNodeType() == Node.COMMENT_NODE && isDocumentState()) {
+      // Base class drops comment nodes at document/fragment root level — emit them explicitly.
+      _printer.printText("<!--");
+      _printer.printText(((Comment) node).getData());
+      _printer.printText("-->");
+    } else {
+      super.serializeNode(node);
+    }
   }
 
   /**

--- a/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
+++ b/src/test/java/org/owasp/validator/html/test/AntiSamyTest.java
@@ -54,6 +54,7 @@ import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import org.apache.commons.codec.binary.Base64;
 import org.hamcrest.text.MatchesPattern;
 import org.junit.Before;
@@ -2946,5 +2947,103 @@ public class AntiSamyTest {
     output = as.scan("<a rel='nofollow' target='_blank'>Link text</a>", policy, AntiSamy.SAX)
             .getCleanHTML();
     assertThat(output.split("rel=").length - 1, is(1));
+  }
+
+  @Test
+  public void testCommentInsideElementIsPreserved() throws Exception {
+      String input    = "<div><!-- comment inside element --></div>";
+      String expected = "<div/>";
+
+      CleanResults cr = as.scan(input, TestPolicy.getInstance());
+      assertEquals(expected, cr.getCleanHTML().trim());
+
+      expected = "<div>\n  <!-- comment inside element --></div>";
+      Policy testPolicy = TestPolicy.getInstance().cloneWithDirective("preserveComments", "true");
+      cr = as.scan(input, testPolicy);
+      assertEquals(expected, cr.getCleanHTML().trim());
+  }
+
+  @Test
+  public void testCommentAtRootLevelIsPreserved() throws Exception {
+      String input    = "<!-- root level comment -->";
+      String expected = "";
+
+      CleanResults cr = as.scan(input, TestPolicy.getInstance());
+      assertEquals(expected, cr.getCleanHTML().trim());
+
+      expected = "<!-- root level comment -->";
+      Policy testPolicy = TestPolicy.getInstance().cloneWithDirective("preserveComments", "true");
+      cr = as.scan(input, testPolicy);
+      assertEquals(expected, cr.getCleanHTML().trim());
+  }
+
+  @Test
+  public void testCommentBeforeElementAtRootLevel() throws Exception {
+      String input    = "<!-- header comment --><div>text</div>";
+      String expected = "<div>text</div>";
+
+      CleanResults cr = as.scan(input, TestPolicy.getInstance());
+      assertEquals(expected, cr.getCleanHTML().trim());
+
+      expected = "<!-- header comment --><div>text</div>";
+      Policy testPolicy = TestPolicy.getInstance().cloneWithDirective("preserveComments", "true");
+      cr = as.scan(input, testPolicy);
+      assertEquals(expected, cr.getCleanHTML().trim());
+  }
+
+  @Test
+  public void testCommentAfterElementAtRootLevel() throws Exception {
+      String input    = "<div>text</div><!-- footer comment -->";
+      String expected = "<div>text</div>";
+
+      CleanResults cr = as.scan(input, TestPolicy.getInstance());
+      assertEquals(expected, cr.getCleanHTML().trim());
+
+      expected = "<div>text</div>\n<!-- footer comment -->";
+      Policy testPolicy = TestPolicy.getInstance().cloneWithDirective("preserveComments", "true");
+      cr = as.scan(input, testPolicy);
+      assertEquals(expected, cr.getCleanHTML().trim());
+  }
+
+  @Test
+  public void testCommentBetweenElementsAtRootLevel() throws Exception {
+      String input    = "<p>first</p><!-- between --><p>second</p>";
+      String expected = "<p>first</p>\n<p>second</p>";
+
+      CleanResults cr = as.scan(input, TestPolicy.getInstance());
+      assertEquals(expected, cr.getCleanHTML().trim());
+
+      expected = "<p>first</p>\n<!-- between --><p>second</p>";
+      Policy testPolicy = TestPolicy.getInstance().cloneWithDirective("preserveComments", "true");
+      cr = as.scan(input, testPolicy);
+      assertEquals(expected, cr.getCleanHTML().trim());
+  }
+
+  @Test
+  public void testMultipleCommentsAtRootLevel() throws Exception {
+      String input    = "<!-- first --><!-- second --><div>text</div><!-- third -->";
+      String expected = "<div>text</div>";
+
+      CleanResults cr = as.scan(input, TestPolicy.getInstance());
+      assertEquals(expected, cr.getCleanHTML().trim());
+
+      expected = "<!-- first --><!-- second --><div>text</div>\n<!-- third -->";
+      Policy testPolicy = TestPolicy.getInstance().cloneWithDirective("preserveComments", "true");
+      cr = as.scan(input, testPolicy);
+      assertEquals(expected, cr.getCleanHTML().trim());
+  }
+
+  @Test
+  public void testOnlyCommentsAtRootLevel() throws Exception {
+      String input    = "<!-- one --><!-- two --><!-- three -->";
+      String expected = "";
+
+      CleanResults cr = as.scan(input, TestPolicy.getInstance());
+      assertEquals(expected, cr.getCleanHTML().trim());
+
+      expected = "<!-- one --><!-- two --><!-- three -->";
+      Policy testPolicy = TestPolicy.getInstance().cloneWithDirective("preserveComments", "true");
+      cr = as.scan(input, testPolicy);
+      assertEquals(expected, cr.getCleanHTML().trim());
   }
 }


### PR DESCRIPTION
ASHTMLSerializer silently drops comment nodes that are direct children of a DocumentFragment even when preserveComments=true